### PR TITLE
Adds possibility to mask some pixels before alignment

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -93,6 +93,13 @@ F1000W = 'F770W'
 F1130W = 'F1000W'
 F2100W = 'F1130W'
 
+[alignment_masking]
+use_ds9_masks = true  # if true, then the areas defined by ds9 region file will be masked before the alignment
+masks_dir = 'masks'  # name of the directory where .reg files are stored, relative to working directory (galname.reg)
+vmin = nan  # minimal brightness of the pixels be considered for cross-correlation
+vmax = nan  # maximal brightness of the pixels be considered for cross-correlation
+min_sn = 25  # minimal signal-to-noise of the pixels be considered for cross-correlation
+
 [lv1_parameters]
 save_results = true
 ramp_fit.suppress_one_group = false

--- a/run_jwst_reprocessing.py
+++ b/run_jwst_reprocessing.py
@@ -91,6 +91,7 @@ for prop_id in prop_ids:
                                astrometric_alignment_type='table',
                                astrometric_alignment_table=alignment_table,
                                alignment_mapping=alignment_mapping,
+                               alignment_masking=config['alignment_masking'],
                                procs=processors,
                                updated_flats_dir=updated_flats_dir,
                                # process_bgr_like_science=False,


### PR DESCRIPTION
Can use ds9 regions, min/max brightness or minimal S/N to limit the pixels that will be considered for cross-correlation with the other JWST bands at the alignment stage.

For example, it is possible to mask galactic centers (helps for e.g. NGC7496) or the regions with low S/N before the alignment. This adds more flexibility to this stage and sometimes (often?) produces better results than just usage of cross-correlation on the unmasked images. 

The new functionality is defined in `alignment_masking` block
ds9 regions defining the regions to be masked should be placed in the directory defined by `masks_dir` parameter (path is relative to working directory)
The names of the files should be in the format "target.reg"

`min_sn `set up the minimal S/N for unmasked pixels
`vmin `and `vmax `- minimal and maximal brightness of the pixels 
For these three parameters `nan` means "ignore"

