### PR TITLE
Modify coronograph masking to keep it in non-overlapping area

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -82,7 +82,7 @@ lev3_fields = [] # indicate numbers of particular field if you want
                   # to limit the level3
 		  # and further reduction by only selected
 		  # pointings (e.g. [1], or [1,2], or 1)
-lyot_method = 'mask' # possible: 'mask', 'mask_overlap', 'adjust', 'keep'
+lyot_method = 'mask' # possible: 'mask', 'mask_overlap', 'adjust'
 
 astrometric_alignment_type = 'table'
 alignment_mapping_mode = 'shift'

--- a/jwst_reprocess.py
+++ b/jwst_reprocess.py
@@ -2046,8 +2046,8 @@ class JWSTReprocess:
                 catalog
             * astrometry_parameter_dict (dict): As `lv1_parameter_dict`, but for astrometric alignment
             * lyot_method (str): Method to account for mistmatch lyot coronagraph in MIRI imaging. Can either mask with
-                `mask`, mask only in overlapping region with `mask_overlap', do nothing with 'keep'
-                 or adjust to main chip with `adjust`. Defaults to `mask`
+                `mask`, mask only in overlapping region with `mask_overlap',
+                or adjust to main chip with `adjust`. Defaults to `mask`
             * dither_match_short_nircam_chips (bool): In dither matching, whether to do a second step where all the
                 chips in a dither are matched before the final matching. Defaults to True, but should be turned off
                 for dither patterns where the chips don't end up overlapping
@@ -2681,13 +2681,6 @@ class JWSTReprocess:
                                            out_dir=out_band_dir,
                                            check_overlap=True
                                            )
-                        elif self.lyot_method == 'keep':
-                            logging.info(f"Coronograph area is untouched")
-                            if not os.path.exists(out_band_dir):
-                                os.makedirs(out_band_dir)
-                            for f in cal_files:
-                                out_name = os.path.join(out_band_dir, os.path.split(f)[-1])
-                                shutil.copy(f, out_name)
 
                     else:
 


### PR DESCRIPTION
Changes for the mask_lyot step. 
With lyot_method = "mask_overlap", the script will identify the chronograph areas that do not overlap with the non-blank science field. Such regions will pass through further reduction steps, while the rest of the chronograph pixels will be masked (in the same way as with lyot_method='mask')