### PR TITLE
Improve large-scale multitile destriping

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,18 @@
+0.10.1 (Unreleased)
+===================
+
+- Can specify CRDS context at the pipeline level
+- median_filter is now the default in ``single_tile_destripe_step``
+- Added fallback for median_filter in ``single_tile_destripe_step`` when too much data is masked
+- Remove mask option in median_filter in ``single_tile_destripe_step``, since it's always used
+  anyway
+- Changed up how ``do_large_scale`` works in ``multi_tile_destripe_step``,
+  which seems significantly improved and simplified
+- Added fallback for in ``multi_tile_destripe_step`` when too much data is masked in quadrants
+- Changed how tweakreg grouping is done in ``get_wcs_adjust_step`` and ``lv3_step`` to account
+  for code changes in the pipeline
+- Added option to decouple the short NIRCam chips for tweakreg in ``lv3_step``
+  
 0.10.0 (2023-11-14)
 ===================
 

--- a/config/2107/astronode.toml
+++ b/config/2107/astronode.toml
@@ -1,4 +1,5 @@
 crds_path = '/data/beegfs/astro-storage/groups/schinnerer/williams/crds/'
+crds_context = 'jwst_1147.pmap'
 raw_dir = '/data/beegfs/astro-storage/groups/schinnerer/williams/jwst_raw/2107/archive_20231015/'
 reprocess_dir = '/data/beegfs/astro-storage/groups/schinnerer/williams/jwst_phangs_reprocessed/'
 alignment_dir = '/data/beegfs/astro-storage/groups/schinnerer/williams/jwst_scripts/config/2107/alignment/'

--- a/config/2107/config.toml
+++ b/config/2107/config.toml
@@ -22,7 +22,7 @@ targets = [
 ]
 
 # Version for the reprocessing
-version = 'v0p9p4'
+version = 'v0p10p1'
 
 # Bands to consider
 bands = [
@@ -53,10 +53,10 @@ steps = [
     'lv2',
     'get_wcs_adjust',
     'apply_wcs_adjust',
-    'multi_tile_destripe.nircam',
-#    'psf_model',
     'lyot_separate.miri',
     'level_match',
+    'multi_tile_destripe.nircam',
+#    'psf_model',
     'lv3',
     'astrometric_catalog.miri',
     'astrometric_align',
@@ -112,12 +112,9 @@ jwst_parameters.bkg_subtract.sigma = 1.5
 
 [parameters.get_wcs_adjust]
 
-overwrite = true
-
 bands = [
     'F300M',
     'F1000W',
-    'F1000W_bgr',
 ]
 
 group_dithers = [
@@ -183,7 +180,6 @@ abs_sigma = 3
 bkg_boxsize.nircam_short = 100
 bkg_boxsize.nircam_long = 100
 bkg_boxsize.miri = 25
-# TODO enforce_user_order = true
 
 [parameters.lyot_mask]
 method = 'mask'
@@ -199,14 +195,11 @@ filter_extend_mode = "reflect"
 filter_scales = [3, 7, 15, 31, 63, 127, 255, 511]
 
 [parameters.multi_tile_destripe]
-apply_to_unflat = false
-do_vertical_subtraction = false
+
 quadrants = true
-sigma = 3
-weight_type = 'equal'
-do_large_scale = false
-large_scale_filter_extend_mode = "reflect"
-weight_method = "sigma_clip"
+weight_type = 'ivm'
+do_large_scale = true
+weight_method = 'mean'
 
 [parameters.level_match]
 do_sigma_clip = false
@@ -264,7 +257,6 @@ use2dhist = false
 bkg_boxsize.nircam_short = 100
 bkg_boxsize.nircam_long = 100
 bkg_boxsize.miri = 25
-# TODO enforce_user_order = true
 
 [parameters.lv3.jwst_parameters.skymatch]
 
@@ -340,7 +332,7 @@ searchrad = 2
 separation = 1
 tolerance = 0.5
 use2dhist = false
-fitgeom = 'rshift' # TODO
+fitgeom = 'shift'  # TODO 'rshift'
 nclip = 5
 sigma = 3
 
@@ -378,4 +370,4 @@ move_backgrounds = true
 move_psf_matched = true
 
 [parameters.regress_against_previous]
-prev_version = 'v0p9p2'
+prev_version = 'v0p10p0'

--- a/pjpipe/lv3/lv3_step.py
+++ b/pjpipe/lv3/lv3_step.py
@@ -38,6 +38,7 @@ class Lv3Step:
         step_ext,
         procs,
         tweakreg_degroup_nircam_modules=False,
+        tweakreg_degroup_nircam_short_chips=False,
         tweakreg_group_dithers=None,
         tweakreg_degroup_dithers=None,
         skymatch_group_dithers=None,
@@ -63,6 +64,9 @@ class Lv3Step:
                 modules. Currently, the WCS is inconsistent between the two,
                 so should probably be set to True if you see "ghosting" in the final
                 mosaic. Defaults to False
+            tweakreg_degroup_nircam_short_chips: Whether to degroup NIRCam short 1/2/3/4
+                chips. There may be some shifts between these, so should ideally find a shift
+                for each chip. Defaults to False
             tweakreg_group_dithers: List of 'miri',
                 'nircam_long', 'nircam_short' of whether to group
                 up dithers for tweakreg. Defaults to None, which will
@@ -112,6 +116,7 @@ class Lv3Step:
         self.step_ext = step_ext
         self.procs = procs
         self.tweakreg_degroup_nircam_modules = tweakreg_degroup_nircam_modules
+        self.tweakreg_degroup_nircam_short_chips = tweakreg_degroup_nircam_short_chips
         self.tweakreg_group_dithers = tweakreg_group_dithers
         self.tweakreg_degroup_dithers = tweakreg_degroup_dithers
         self.skymatch_group_dithers = skymatch_group_dithers
@@ -310,43 +315,86 @@ class Lv3Step:
 
             recursive_setattr(tweakreg, tweakreg_key, value)
 
-        # Keep track of exposure numbers in case we change them
-        exposure_numbers = {}
+        # Keep track of exposure numbers and group IDs in case we change them
+        meta_params = {}
         for model in asn_file._models:
             model_name = model.meta.filename
-            exposure_numbers[model_name] = model.meta.observation.exposure_number
+            meta_params[model_name] = [model.meta.observation.exposure_number,
+                                       model.meta.group_id,
+                                       ]
 
         # Group up the dithers
         if short_long in self.tweakreg_group_dithers:
             for model in asn_file._models:
                 model.meta.observation.exposure_number = "1"
+                model.meta.group_id = ""
 
         # Or degroup the dithers
         elif short_long in self.tweakreg_degroup_dithers:
             for i, model in enumerate(asn_file._models):
                 model.meta.observation.exposure_number = str(i)
+                model.meta.group_id = ""
 
         # If needed, degroup the NIRCam modules. Do this by changing the
         # first letter of the filename to the module, and adding a large
-        # number to the exposure number to degroup them
+        # number to the exposure number to degroup them.
         if (
             band_type == "nircam"
             and self.tweakreg_degroup_nircam_modules
-            and short_long not in self.tweakreg_degroup_dithers
         ):
             for i, model in enumerate(asn_file._models):
                 module = model.meta.instrument.module.strip().lower()
 
                 exp_no = int(model.meta.observation.exposure_number)
                 if module == "a":
-                    model.meta.observation.exposure_number = str(exp_no + 99)
+                    exp_add = 99
                 elif module == "b":
-                    model.meta.observation.exposure_number = str(exp_no + 100)
+                    exp_add = 100
                 else:
                     raise ValueError("Expecting module to either be A or B")
 
+                model.meta.observation.exposure_number = str(exp_no + exp_add)
+                model.meta.group_id = ""
+
                 model_name = list(copy.deepcopy(model.meta.filename))
                 model_name[0] = module
+                model_name = "".join(model_name)
+                model.meta.filename = copy.deepcopy(model_name)
+
+        # Degroup the 1/2/3/4 NIRCam shorts, if requested
+        if (
+            band_type == "nircam"
+            and self.tweakreg_degroup_nircam_short_chips
+        ):
+            for i, model in enumerate(asn_file._models):
+                detector = model.meta.instrument.detector.strip().lower()
+
+                exp_no = int(model.meta.observation.exposure_number)
+
+                # Include information from the particular chip if we're in short
+                # mode (i.e. there's a 1-4 in the detector name), and keep
+                # track of this to modify the name later
+                exp_add = 0
+                if "1" in detector:
+                    exp_add += 49
+                    det = "1"
+                elif "2" in detector:
+                    exp_add += 50
+                    det = "2"
+                elif "3" in detector:
+                    exp_add += 51
+                    det = "3"
+                elif "4" in detector:
+                    exp_add += 52
+                    det = "4"
+                else:
+                    det = "l"
+
+                model.meta.observation.exposure_number = str(exp_no + exp_add)
+                model.meta.group_id = ""
+
+                model_name = list(copy.deepcopy(model.meta.filename))
+                model_name.insert(1, det)
                 model_name = "".join(model_name)
                 model.meta.filename = copy.deepcopy(model_name)
 
@@ -362,22 +410,37 @@ class Lv3Step:
         if (
             band_type == "nircam"
             and self.tweakreg_degroup_nircam_modules
-            and short_long not in self.tweakreg_degroup_dithers
         ):
             for i, model in enumerate(asn_file._models):
                 model_name = list(copy.deepcopy(model.meta.filename))
                 model_name[0] = "j"
                 model_name = "".join(model_name)
                 model.meta.filename = copy.deepcopy(model_name)
+                model.meta.observation.exposure_number = meta_params[model_name][0]
+                model.meta.group_id = meta_params[model_name][1]
 
-        # Set exposure numbers back to original values to avoid potential weirdness later
+        # Remove the chip info if we're degrouping the NIRCam short chips
+        if (
+                band_type == "nircam"
+                and self.tweakreg_degroup_nircam_short_chips
+        ):
+            for i, model in enumerate(asn_file._models):
+                model_name = list(copy.deepcopy(model.meta.filename))
+                model_name.pop(1)
+                model_name = "".join(model_name)
+                model.meta.filename = copy.deepcopy(model_name)
+                model.meta.observation.exposure_number = meta_params[model_name][0]
+                model.meta.group_id = meta_params[model_name][1]
+
+        # Set meta parameters back to original values to avoid potential weirdness later
         if (
             short_long in self.tweakreg_group_dithers
             or short_long in self.tweakreg_degroup_dithers
         ):
             for i, model in enumerate(asn_file._models):
                 model_name = model.meta.filename
-                model.meta.observation.exposure_number = exposure_numbers[model_name]
+                model.meta.observation.exposure_number = meta_params[model_name][0]
+                model.meta.group_id = meta_params[model_name][1]
 
         # Run the skymatch step with custom hacks if required
         config = SkyMatchStep.get_config_from_reference(asn_file)
@@ -407,24 +470,27 @@ class Lv3Step:
         if short_long in self.skymatch_group_dithers:
             for model in asn_file._models:
                 model.meta.observation.exposure_number = "1"
+                model.meta.group_id = ""
 
         elif short_long in self.skymatch_degroup_dithers:
             for i, model in enumerate(asn_file._models):
                 model.meta.observation.exposure_number = str(i)
+                model.meta.group_id = ""
 
         asn_file = skymatch.run(asn_file)
 
         del skymatch
         gc.collect()
 
-        # Set exposure numbers back to original values to avoid potential weirdness later
+        # Set meta parameters back to original values to avoid potential weirdness later
         if (
             short_long in self.skymatch_group_dithers
             or short_long in self.skymatch_degroup_dithers
         ):
             for i, model in enumerate(asn_file._models):
                 model_name = model.meta.filename
-                model.meta.observation.exposure_number = exposure_numbers[model_name]
+                model.meta.observation.exposure_number = meta_params[model_name][0]
+                model.meta.group_id = meta_params[model_name][1]
 
         im3.skymatch.skip = True
 

--- a/pjpipe/pipeline.py
+++ b/pjpipe/pipeline.py
@@ -138,6 +138,12 @@ class PJPipeline:
 
         log.info("Starting PHANGS-JWST pipeline")
 
+        if "crds_context" in local:
+            crds_context = local["crds_context"]
+            os.environ['CRDS_CONTEXT'] = copy.deepcopy(crds_context)
+        else:
+            crds_context = "Default"
+
         # Pull in needed values from the configs
         self.targets = config["targets"]
         self.bands = config["bands"]
@@ -175,6 +181,7 @@ class PJPipeline:
         # Log the environment variables that should be set
         log.info(f"Using CRDS_SERVER_URL: {os.environ['CRDS_SERVER_URL']}")
         log.info(f"Using CRDS_PATH: {os.environ['CRDS_PATH']}")
+        log.info(f"Using CRDS_CONTEXT: {crds_context}")
         log.info(f"Using {self.procs} processes")
 
         # Log targets/band/steps out

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ cmocean
 pypdf
 setuptools
 stdatamodels
+shapely


### PR DESCRIPTION
Keeping as draft for now, until I've checked it works across the Cy1 stuff

This PR addresses the persistent large-scale ripples in the data present across multiple tiles. It does a large-scale smooth and subtracts to try and fix any remaining stripes after the image stack has been produced. Previously this was after reprojection to the single tile, which caused edge-effects and rippled through to the background matching. It seems much more stable now, and the number of variables has decreased considerably