### PR TITLE
Allow absolute reference catalog in get_wcs_adjust_step.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ==================
 
 - Added PSF modelling routines. These are currently very preliminary, but at least exist
+- Allow for external, absolute catalog in ``get_wcs_adjust_step``
 
 0.9.3 (2023-10-24)
 ==================

--- a/config/2107/config.toml
+++ b/config/2107/config.toml
@@ -54,7 +54,7 @@ steps = [
     'get_wcs_adjust',
     'apply_wcs_adjust',
     'multi_tile_destripe.nircam',
-    'psf_model',
+#    'psf_model',
     'lyot_separate.miri',
     'level_match',
     'lv3',
@@ -112,6 +112,8 @@ jwst_parameters.bkg_subtract.sigma = 1.5
 
 [parameters.get_wcs_adjust]
 
+overwrite = true
+
 bands = [
     'F300M',
     'F1000W',
@@ -123,32 +125,65 @@ group_dithers = [
     'miri',
 ]
 
+[parameters.get_wcs_adjust.alignment_catalogs]
+
+ic5332 = 'ic5332_agb_cat.fits'
+ngc0628 = 'ngc0628_agb_cat.fits'
+ngc1087 = 'ngc1087_agb_cat.fits'
+ngc1300 = 'ngc1300_agb_cat.fits'
+ngc1365 = 'ngc1365_agb_cat.fits'
+ngc1385 = 'ngc1385_agb_cat.fits'
+ngc1433 = 'ngc1433_agb_cat.fits'
+ngc1512 = 'ngc1512_agb_cat.fits'
+ngc1566 = 'ngc1566_agb_cat.fits'
+ngc1672 = 'ngc1672_agb_cat.fits'
+ngc2835 = 'ngc2835_agb_cat.fits'
+ngc3351 = 'ngc3351_agb_cat.fits'
+ngc3627 = 'ngc3627_agb_cat.fits'
+ngc4254 = 'ngc4254_agb_cat.fits'
+ngc4303 = 'ngc4303_agb_cat.fits'
+ngc4321 = 'ngc4321_agb_cat.fits'
+ngc4535 = 'ngc4535_agb_cat.fits'
+ngc5068 = 'ngc5068_agb_cat.fits'
+ngc7496 = 'ngc7496_agb_cat.fits'
+
 [parameters.get_wcs_adjust.tweakreg_parameters]
 
 align_to_gaia = false
 brightest = 500
 snr_threshold = 3
 expand_refcat = true
-fitgeometry = 'shift'
-minobj = 3
 peakmax.nircam = 20
 roundlo.nircam = -0.5
 roundhi.nircam = 0.5
 
 # Parameters to get wcs_adjust shifts
+minobj = 3
 searchrad = 2
 separation.miri = 1
 tolerance.miri = 0.7
 separation.nircam = 2
 tolerance.nircam = 1
 use2dhist = true
+fitgeometry = 'shift'
 nclip = 5
+
+# Parameters for matching to the external catalog
+abs_minobj = 3
+abs_searchrad.miri = 10
+abs_searchrad.nircam = 20
+abs_separation = 1
+abs_tolerance = 1
+abs_use2dhist = true
+abs_fitgeometry = 'shift'
+abs_nclip = 5
+abs_sigma = 3
 
 # Tweak boxsize, so we detect objects in diffuse emission
 bkg_boxsize.nircam_short = 100
 bkg_boxsize.nircam_long = 100
 bkg_boxsize.miri = 25
-enforce_user_order = true
+# TODO enforce_user_order = true
 
 [parameters.lyot_mask]
 method = 'mask'
@@ -198,7 +233,7 @@ save_results = true
 [parameters.lv3.jwst_parameters.tweakreg]
 
 # Skip MIRI wavelengths, since we have already
-# solved for this
+# solved for this and this can make things worse
 skip.F770W = true
 skip.F1000W = true
 skip.F1130W = true
@@ -229,7 +264,7 @@ use2dhist = false
 bkg_boxsize.nircam_short = 100
 bkg_boxsize.nircam_long = 100
 bkg_boxsize.miri = 25
-enforce_user_order = true
+# TODO enforce_user_order = true
 
 [parameters.lv3.jwst_parameters.skymatch]
 
@@ -269,14 +304,14 @@ roundhi = 0.5
 [parameters.astrometric_align]
 
 [parameters.astrometric_align.align_mapping]
-# Map everything to F1000W, since it has the most point sources
-F770W = 'F1000W'
-F1130W = 'F1000W'
-F2100W = 'F1000W'
+# TODO: Maybe we don't do this now? Map everything to F1000W, since it has the most point sources
+#F770W = 'F1000W'
+#F1130W = 'F1000W'
+#F2100W = 'F1000W'
 
-F770W_bgr = 'F1000W_bgr'
-F1130W_bgr = 'F1000W_bgr'
-F2100W_bgr = 'F1000W_bgr'
+#F770W_bgr = 'F1000W_bgr'
+#F1130W_bgr = 'F1000W_bgr'
+#F2100W_bgr = 'F1000W_bgr'
 
 [parameters.astrometric_align.catalogs]
 ic5332 = 'ic5332_agb_cat.fits'
@@ -299,27 +334,13 @@ ngc4535 = 'ngc4535_agb_cat.fits'
 ngc5068 = 'ngc5068_agb_cat.fits'
 ngc7496 = 'ngc7496_agb_cat.fits'
 
-# Initial pass to get decent shifts for absolute astrometry
-[parameters.astrometric_align.tweakreg_parameters.iteration1]
-
-# Set quite a large search radius
-searchrad.miri = 10
-searchrad.nircam_long = 20
-searchrad.nircam_short = 40
-separation = 1
-tolerance = 1
-use2dhist = true
-fitgeom = 'shift'
-nclip = 5
-sigma = 3
-
-# Second iteration with tightened up parameters to figure out any residual shifts left
-[parameters.astrometric_align.tweakreg_parameters.iteration2]
+# Residual shifts should be small, so use tight parameters here. Allow for rotation
+[parameters.astrometric_align.tweakreg_parameters]
 searchrad = 2
 separation = 1
 tolerance = 0.5
 use2dhist = false
-fitgeom = 'shift'
+fitgeom = 'rshift' # TODO
 nclip = 5
 sigma = 3
 

--- a/pjpipe/pipeline.py
+++ b/pjpipe/pipeline.py
@@ -273,6 +273,7 @@ class PJPipeline:
                             directory=target_dir,
                             progress_dict=progress_dict[target],
                             target=target,
+                            alignment_dir=self.alignment_dir,
                             **step_parameters,
                         )
                         step_result = get_wcs_adjust.do_step()


### PR DESCRIPTION
Allows you to specify an absolute reference catalogue in the get_wcs_adjust_step. We're building towards basically being there by level 3, so we can do some fancier stuff to hammer out the lingering low-level astrometry issues