### PR TITLE
Compress diagnostic plots

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.10.2 (Unreleased)
+===================
+
+- Diagnostic plots are compressed by default in ``release_step``
+
 0.10.1 (2023-11-20)
 ===================
 


### PR DESCRIPTION
Compress the diagnostic plots in the release step by default. There's a lot of them!