### PR TITLE
Fix edge case in single_tile_destripe_step.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 0.10.2 (Unreleased)
 ===================
 
+- Fix crash where quadrants are turned off in median filtering in ``single_tile_destripe_step``
 - Diagnostic plots are compressed by default in ``release_step``
 
 0.10.1 (2023-11-20)

--- a/pjpipe/single_tile_destripe/single_tile_destripe_step.py
+++ b/pjpipe/single_tile_destripe/single_tile_destripe_step.py
@@ -1417,14 +1417,14 @@ class SingleTileDestripeStep:
                 med = med.data
                 med[mask_idx] = np.nan
 
-                mask = np.isnan(med)
+                med_mask = np.isnan(med)
 
                 # Only interp if we have a) some NaNs but not b) all NaNs
-                if 0 < np.sum(mask) < len(med):
-                    med[mask] = np.interp(np.flatnonzero(mask),
-                                          np.flatnonzero(~mask),
-                                          med[~mask],
-                                          )
+                if 0 < np.sum(med_mask) < len(med):
+                    med[med_mask] = np.interp(np.flatnonzero(med_mask),
+                                              np.flatnonzero(~med_mask),
+                                              med[~med_mask],
+                                              )
 
                 noise = med - median_filter(med, scale, mode=self.filter_extend_mode)
 


### PR DESCRIPTION
Thanks Jeremy for spotting this one, renamed a variable that was causing issues if you destripe without quadrants on