### PR TITLE
Remove error in multi_tile_destripe_step.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 0.10.2 (Unreleased)
 ===================
 
+- Remove an error in ``multi_tile_destripe_step`` stripes in stacked image don't align with any particular
+  axis of the array
 - Fix crash where quadrants are turned off in median filtering in ``single_tile_destripe_step``
 - Diagnostic plots are compressed by default in ``release_step``
 

--- a/pjpipe/multi_tile_destripe/multi_tile_destripe_step.py
+++ b/pjpipe/multi_tile_destripe/multi_tile_destripe_step.py
@@ -574,7 +574,7 @@ class MultiTileDestripeStep:
 
             # First case, we have a weird mix of rotations. In which case direction should be None
             if not np.all(internal_diff < 10):
-                raise ValueError("Input images have a variety of rotations. Have not enocuntered this before")
+                raise ValueError("Input images have a variety of rotations. Have not encountered this before")
                 direction = None
                 log.info("Input images have a variety of rotations. Defaulting to smoothing over both axes")
 
@@ -591,8 +591,6 @@ class MultiTileDestripeStep:
             # Final case, they're aligned but not along any particular axis in the image. In this case,
             # direction should be None
             else:
-                raise ValueError("Input images are aligned, but not along any particular direction. "
-                                 "Have not encountered this before")
                 direction = None
                 log.info("Stacked image does not align over a particular axis. Smoothing over both axes")
 


### PR DESCRIPTION
This PR fixes an issue in multi_tile_destripe where we don't have square/rectangular mosaics, meaning the stacked image will have stripes not aligned with an axis of the array. In this case we fall back and smooth over both axes, which seems to work fine. Thanks to Jeremy Chastenet for testing this one!