### PR TITLE
Fix too many open plots in anchoring step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 - Made plots more consistent and "publication ready" across the board
 - Fix bug in anchoring step
 - Rename anchor_to_external_step.py to anchor_step.py for consistency
+- Fix "too many plots open" warning in anchoring_step.py
 
 1.0.2 (2023-12-01)
 ==================

--- a/pjpipe/anchoring/anchoring_step.py
+++ b/pjpipe/anchoring/anchoring_step.py
@@ -295,6 +295,8 @@ def solve_for_offset(
         plt.savefig(f"{save_plot}.png", bbox_inches="tight", dpi=300)
         plt.savefig(f"{save_plot}.pdf", bbox_inches="tight", dpi=300)
 
+        plt.close()
+
     return slope, intercept
 
 


### PR DESCRIPTION
There was a missing plt.close() at the end of the anchoring plotting part. Fixed!