### PR TITLE
Point Zenodo DOI to "concept", rather than latest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+1.0.5 (Unreleased)
+==================
+
+- Point Zenodo DOI to "concept" DOI, rather than latest
+
 1.0.4 (2024-01-04)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Docs](https://readthedocs.org/projects/pjpipe/badge/?version=latest&style=flat-square)](https://pjpipe.readthedocs.io/en/latest/)
 [![Actions](https://img.shields.io/github/actions/workflow/status/phangsTeam/pjpipe/build_test.yaml?branch=main&style=flat-square)](https://github.com/phangsTeam/pjpipe/actions)
 [![License](https://img.shields.io/badge/license-GNUv3-blue.svg?label=License&style=flat-square)](LICENSE)
-[![DOI](https://img.shields.io/badge/DOI-10.5281%20%2F%20zenodo.10458747-blue.svg?style=flat-square)](https://zenodo.org/doi/10.5281/zenodo.10458746)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%20%2F%20zenodo.10458746-blue.svg?style=flat-square)](https://zenodo.org/doi/10.5281/zenodo.10458746)
 
 ![](docs/images/pjpipe_logo.jpg)
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -11,7 +11,7 @@ PJPipe
 .. image:: https://readthedocs.org/projects/pjpipe/badge/?version=latest&style=flat-square
    :target: https://pjpipe.readthedocs.io/en/latest/
 .. image:: https://img.shields.io/badge/license-GNUv3-blue.svg?label=License&style=flat-square
-.. image:: https://img.shields.io/badge/DOI-10.5281%20%2F%20zenodo.10458747-blue.svg?style=flat-square
+.. image:: https://img.shields.io/badge/DOI-10.5281%20%2F%20zenodo.10458746-blue.svg?style=flat-square
    :target: https://zenodo.org/doi/10.5281/zenodo.10458746
 
 **Note that this pipeline requires Python 3.9 or above**


### PR DESCRIPTION
To avoid the DOI changing, the badges now point at the concept DOI Zenodo mints, rather than whatever the latest version is