### PR TITLE
Add proper reference for PCA

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ==================
 
 - Point Zenodo DOI to "concept" DOI, rather than latest
+- Add acknowledgment for PCA (thanks Liz!)
 
 1.0.4 (2024-01-04)
 ==================

--- a/README.md
+++ b/README.md
@@ -204,3 +204,6 @@ PJPipe has been developed by the [PHANGS Team](phangs.org), with major contribut
 * Jessica Sutter (UCSD)
 * David Thilker (JHU)
 * Adam Leroy (OSU)
+
+The PCA implementation for NIRCam destriping was adapted from work by Elizabeth Watkins 
+(University of Manchester), and up-to-date code is available at [this Github repository](https://github.com/ejwatkins-astro/robitgapca).

--- a/docs/steps/single_tile_destripe.rst
+++ b/docs/steps/single_tile_destripe.rst
@@ -14,6 +14,10 @@ be corrected before flat-fielding.
 If you have subarray observations, ``quadrants`` will automatically be set to ``False``, as the readout is different
 in these modes.
 
+The PCA implementation for NIRCam destriping was adapted from work by Elizabeth Watkins
+(University of Manchester), and up-to-date code is available at
+`this GitHub repository <https://github.com/ejwatkins-astro/robitgapca>`_.
+
 ---
 API
 ---


### PR DESCRIPTION
Adds in reference to Liz's github repo for the PCA, and acknowledges both in credits and the single_tile_destripe step docs