### PR TITLE
Cleaner labels in anchoring_step.py

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@
 ==================
 
 - Point Zenodo DOI to "concept" DOI, rather than latest
+- Cleaner labels in ``anchoring_step``
 
 1.0.4 (2024-01-04)
 ==================


### PR DESCRIPTION
This PR cleans up the labels in the anchoring plots, first by capitalising bands (e.g. irac1->IRAC1), and optionally stripping out convolution details (e.g. irac1_atgauss4->irac1). It also changes flux->intensity, so F->I in the x/y label