### PR TITLE
Fix in parse_fits_to_table for no defined obs label

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 1.0.5 (Unreleased)
 ==================
 
+- Fix in ``parse_fits_to_table`` when there is not a defined observation label
 - Point Zenodo DOI to "concept" DOI, rather than latest
 - Cleaner labels in ``anchoring_step``
 - Add acknowledgment for PCA (thanks Liz!)

--- a/pjpipe/utils/utils.py
+++ b/pjpipe/utils/utils.py
@@ -527,7 +527,14 @@ def parse_fits_to_table(
         obs_filter = im.meta.instrument.filter
         obs_date = im.meta.observation.date_beg
         obs_duration = im.meta.exposure.duration
-        obs_label = im.meta.observation.observation_label.lower()
+
+        # Sometimes the observation label is not defined, so have a fallback here
+        obs_label = im.meta.observation.observation_label
+        if obs_label is not None:
+            obs_label = obs_label.lower()
+        else:
+            obs_label = ""
+
         obs_program = im.meta.observation.program_number
         array_name = im.meta.subarray.name.lower().strip()
 


### PR DESCRIPTION
Addresses #54

Fixes a bug where lv2 (and presumably 3) will crash when building the observation table if there isn't an observation label defined

Currently a draft until we verify this works