### PR TITLE
Added 'filename' option for background association

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 1.0.5 (Unreleased)
 ==================
 
+- Added 'filename' option for background association
 - Fix in ``parse_fits_to_table`` when there is not a defined observation label
 - Point Zenodo DOI to "concept" DOI, rather than latest
 - Cleaner labels in ``anchoring_step``

--- a/pjpipe/lv2/lv2_step.py
+++ b/pjpipe/lv2/lv2_step.py
@@ -11,7 +11,7 @@ from functools import partial
 
 import jwst
 import numpy as np
-from astropy.table import Table
+from astropy.table import Table, vstack
 from jwst.pipeline import calwebb_image2
 from stdatamodels.jwst import datamodels
 
@@ -19,6 +19,12 @@ from ..utils import get_band_type, get_obs_table, attribute_setter, save_file
 
 log = logging.getLogger("stpipe")
 log.addHandler(logging.NullHandler())
+
+BGR_CHECK_TYPES = [
+    "parallel_off",
+    "check_in_name",
+    "filename",
+]
 
 
 class Lv2Step:
@@ -52,10 +58,10 @@ class Lv2Step:
             is_bgr: Whether we're processing background observations or not
             procs: Number of processes to run in parallel
             bgr_check_type: Method to check if obs is science
-                or background. Options are 'parallel_off' and
-                'check_in_name'. Defaults to 'parallel_off'
-            bgr_background_name: If `bgr_check_type` is 'check_in_name',
-                this is the string to match
+                or background. Options are given by BGR_CHECK_TYPES.
+                Defaults to 'parallel_off'
+            bgr_background_name: If `bgr_check_type` is 'check_in_name'
+                or 'filename', this is the string to match
             bgr_observation_types: List of observation types with dedicated
                 backgrounds. Defaults to None, i.e. no observations have
                 backgrounds
@@ -186,7 +192,7 @@ class Lv2Step:
         # If we're processing backgrounds like science,
         # join the tables
         if self.process_bgr_like_science and not self.is_bgr:
-            full_tab = sci_tab + bgr_tab
+            full_tab = vstack([sci_tab, bgr_tab])
             full_tab["Type"] = "sci"
 
         # If we're processing background observations,

--- a/pjpipe/lv3/lv3_step.py
+++ b/pjpipe/lv3/lv3_step.py
@@ -28,6 +28,12 @@ from ..utils import (
 log = logging.getLogger("stpipe")
 log.addHandler(logging.NullHandler())
 
+BGR_CHECK_TYPES = [
+    "parallel_off",
+    "check_in_name",
+    "filename",
+]
+
 
 class Lv3Step:
     def __init__(
@@ -88,10 +94,10 @@ class Lv3Step:
                 skymatch. Defaults to None, which will keep at
                 default.
             bgr_check_type: Method to check if obs is science
-                or background. Options are 'parallel_off' and
-                'check_in_name'. Defaults to 'parallel_off'
-            bgr_background_name: If `bgr_check_type` is 'check_in_name',
-                this is the string to match
+                or background. Options are given by BGR_CHECK_TYPES.
+                Defaults to 'parallel_off'
+            bgr_background_name: If `bgr_check_type` is 'check_in_name'
+                or 'filename', this is the string to match
             process_bgr_like_science: If True, will process background
                 images as if they are science images. Defaults to False
             jwst_parameters: Parameter dictionary to pass to


### PR DESCRIPTION
This PR adds a new way to associate backgrounds through the filename. This gives more granular control through the im.meta.filename attribute of the ASDF file