### PR TITLE
Allow control over reproject function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 1.1.1 (Unreleased)
 ==================
 
+- Add control over reproject functions, can be ``reproject_interp`` (default), ``reproject_exact``,
+  or ``reproject_adaptive``. For MIRI, ``reproject_exact`` may work better. This applies to ``anchoring_step``,
+  ``astrometric_align_step``, ``level_match_step``, ``multi_tile_destripe_step``, ``psf_matching_step``, and
+  ``release_step``
+- Fix bug for parameters with 'pix' in getting picked up like numbers of pixels
+- Updated PHANGS Cy3 config
 - Include links to Francesco Belfiore's kernel generation repository in the docs
 
 1.1.0 (2024-03-04)

--- a/config/3707/astronode.toml
+++ b/config/3707/astronode.toml
@@ -1,6 +1,6 @@
 crds_path = '/data/beegfs/astro-storage/groups/schinnerer/williams/crds/'
 raw_dir = '/data/beegfs/astro-storage/groups/schinnerer/williams/jwst_raw/3707/20231005/'
 reprocess_dir = '/data/beegfs/astro-storage/groups/schinnerer/williams/jwst_3707/'
-alignment_dir = '/data/beegfs/astro-storage/groups/schinnerer/williams/jwst_scripts/config/3707/alignment/'
+alignment_dir = '/data/beegfs/astro-storage/groups/schinnerer/williams/pjpipe/config/3707/alignment/'
 #webb_psf_data = '/data/beegfs/astro-storage/groups/schinnerer/williams/webbpsf-data'
 processors = 20

--- a/config/3707/config.toml
+++ b/config/3707/config.toml
@@ -1,12 +1,22 @@
 # List of targets
 targets = [
+    'ngc1511',
+    'ngc2283',
+    'ngc1637',
+    'ngc1792',
+    'ngc1808',
+    # 'ngc1068', # run separately
     'ic5273',
-    'ngc1559',
     'ngc7456',
+    'ngc1809',
+    'ngc1546',
+    'ngc1559',
+    'ngc2090',
+    'ngc1097',
 ]
 
 # Version for the reprocessing
-version = 'v0p0p3'
+version = 'v0p1p6'
 
 # Bands to consider
 bands = [
@@ -23,21 +33,24 @@ bands = [
 
 # Steps. These can/should be different
 # for NIRCam and MIRI, and we can distinguish them here
+
 steps = [
     'download',
     'gaia_query',
     'lv1',
-    'lv2',
     'single_tile_destripe.nircam',
+    'lv2',
     'get_wcs_adjust',
     'apply_wcs_adjust',
     'lyot_separate.miri',
-    'multi_tile_destripe.nircam',
     'level_match',
+    'multi_tile_destripe.nircam',
 #    'psf_model',  # TODO
     'lv3',
+    'astrometric_catalog.miri',
     'astrometric_align',
-    'mosaic_individual_fields',
+    'anchoring',
+    'psf_matching',
     'release',
     'regress_against_previous',
 ]
@@ -61,11 +74,6 @@ radius = 20
 [parameters.lv1]
 
 jwst_parameters.save_results = true
-
-# Flag snowballs in NIRCam
-#jwst_parameters.jump.expand_large_events.F187N = true
-jwst_parameters.jump.expand_large_events.nircam = true
-
 jwst_parameters.ramp_fit.suppress_one_group = false
 jwst_parameters.refpix.use_side_ref_pixels = true
 
@@ -86,7 +94,6 @@ jwst_parameters.bkg_subtract.sigma = 1.5
 bands = [
     'F300M',
     'F770W',
-    'F770W_bgr',
 ]
 
 group_dithers = [
@@ -96,30 +103,29 @@ group_dithers = [
 
 [parameters.get_wcs_adjust.tweakreg_parameters]
 
-align_to_gaia = false
+starfinder = 'iraf'
 brightest = 500
 snr_threshold = 3
 expand_refcat = true
-fitgeometry = 'shift'
-minobj = 3
 peakmax.nircam = 20
 roundlo.nircam = -0.5
 roundhi.nircam = 0.5
 
 # Parameters to get wcs_adjust shifts
+minobj = 3
+sigma = 2
 searchrad = 2
 separation.miri = 1
-tolerance.miri = 0.7
 separation.nircam = 2
-tolerance.nircam = 1
+tolerance = 0.3
 use2dhist = true
+fitgeometry = 'shift'
 nclip = 5
 
 # Tweak boxsize, so we detect objects in diffuse emission
 bkg_boxsize.nircam_short = 100
 bkg_boxsize.nircam_long = 100
 bkg_boxsize.miri = 25
-enforce_user_order = true
 
 [parameters.lyot_mask]
 method = 'mask'
@@ -136,7 +142,6 @@ filter_scales = [3, 7, 15, 31, 63, 127, 255, 511]
 
 [parameters.multi_tile_destripe]
 quadrants = true
-sigma = 3
 weight_type = 'ivm'
 do_large_scale = true
 large_scale_filter_extend_mode = "reflect"
@@ -170,7 +175,8 @@ save_results = true
 skip.F770W = true
 skip.F2100W = true
 
-align_to_gaia = false
+# align_to_gaia = false # no longer a tweakreg parameter
+starfinder = 'iraf'
 brightest.nircam_short = 125
 brightest.nircam_long = 500
 brightest.miri = 500
@@ -195,7 +201,6 @@ use2dhist = false
 bkg_boxsize.nircam_short = 100
 bkg_boxsize.nircam_long = 100
 bkg_boxsize.miri = 25
-enforce_user_order = true
 
 [parameters.lv3.jwst_parameters.skymatch]
 
@@ -225,6 +230,7 @@ deblend = true
 
 [parameters.astrometric_catalog]
 snr = 10
+starfind_method = "iraf"
 
 [parameters.astrometric_catalog.dao_parameters]
 sharplo = 0.2
@@ -239,10 +245,23 @@ roundhi = 0.5
 F2100W = 'F770W'
 F2100W_bgr = 'F770W_bgr'
 
+# F150W = 'F300M'
+# F187N = 'F335M'
+
 [parameters.astrometric_align.catalogs]
 ic5273 = 'Gaia_DR3_ic5273.fits'
 ngc1559 = 'ngc1559_agb_cat.fits'
 ngc7456 = 'Gaia_DR3_ngc7456.fits'
+ngc1809 = 'Gaia_DR3_ngc1809.fits'
+ngc1546 = 'Gaia_DR3_ngc1546.fits'
+ngc1511 = 'Gaia_DR3_ngc1511.fits'
+ngc2090 = 'Gaia_DR3_ngc2090.fits'
+ngc1097 = 'Gaia_DR3_ngc1097.fits'
+ngc1068 = 'Gaia_DR3_ngc1068.fits'
+ngc1808 = 'Gaia_DR3_ngc1808.fits'
+ngc1792 = 'Gaia_DR3_ngc1792.fits'
+ngc1637 = 'Gaia_DR3_ngc1637.fits'
+ngc2283 = 'Gaia_DR3_ngc2283.fits'
 
 # Initial pass to get decent shifts for absolute astrometry
 [parameters.astrometric_align.tweakreg_parameters.iteration1]
@@ -253,7 +272,7 @@ searchrad.nircam_long = 20
 searchrad.nircam_short = 40
 separation = 1
 tolerance = 1
-use2dhist = true
+use2dhist = false # Changed 13 Feb 24 -- to remove catastrophic fails
 fitgeom = 'shift'
 nclip = 5
 sigma = 3
@@ -264,15 +283,47 @@ searchrad = 2
 separation = 1
 tolerance = 0.5
 use2dhist = false
-fitgeom = 'shift'
+fitgeom = 'rshift'
 nclip = 5
 sigma = 3
 
+
+[parameters.anchoring]
+
+internal_conv_band = 'F2100W'
+
+[parameters.anchoring.ref_band]
+miri = 'F770W'
+nircam = 'F300M'
+
+# List external bands in preference order
+[parameters.anchoring.external_bands]
+miri = [
+    'irac4_atgauss4',
+    'w3_atgauss15',
+]
+nircam = [
+    'irac1_atgauss4',
+    'w1_atgauss7p5',
+    'irac2_atgauss4',
+    'w2_atgauss7p5',
+]
+
+[parameters.psf_matching]
+
+target_bands = [
+    "gauss0p85",
+    "gauss0p90",
+    "gauss1",
+]
+
+
 [parameters.release]
 
-remove_bloat = true
-move_tweakback = false
-move_backgrounds = false
+move_tweakback = true
+move_backgrounds = true
+move_psf_matched = true
+move_diagnostic_plots = true
 
 [parameters.regress_against_previous]
-prev_version = 'v0p0p2'
+prev_version = 'v0p1p5'

--- a/config/3707/mac.toml
+++ b/config/3707/mac.toml
@@ -1,0 +1,7 @@
+crds_path = '/Users/thomaswilliams/Documents/phangs/jwst/crds/'
+crds_context = 'jwst_1210.pmap'
+raw_dir = '/Users/thomaswilliams/Documents/phangs/jwst/jwst_raw/3707/'
+reprocess_dir = '/Users/thomaswilliams/Documents/phangs/jwst_3707/reprocessing/'
+alignment_dir = '/Users/thomaswilliams/PycharmProjects/pjpipe/config/3707/alignment/'
+webb_psf_data = '/Users/thomaswilliams/Documents/phangs/jwst/webb_psf_data/'
+processors = 4

--- a/config/3707/run_reprocessing.py
+++ b/config/3707/run_reprocessing.py
@@ -6,6 +6,7 @@ this_dir = os.path.dirname(os.path.realpath(__file__))
 
 config_file = os.path.join(this_dir, "config.toml")
 local_file = os.path.join(this_dir, "astronode.toml")
+# local_file = os.path.join(this_dir, "mac.toml")
 
 # We need to set CRDS path
 local = pjpipe.load_toml(local_file)

--- a/pjpipe/psf_matching/psf_matching_step.py
+++ b/pjpipe/psf_matching/psf_matching_step.py
@@ -28,6 +28,7 @@ class PSFMatchingStep:
         in_step_ext,
         band=None,
         target_bands=None,
+        reproject_func="interp",
         overwrite=False,
     ):
         """Match PSF for all images
@@ -45,6 +46,8 @@ class PSFMatchingStep:
             in_step_ext: Filename extension for the input files
             band: Bands to consider
             target_bands: Bands to convolve to
+            reproject_func: Which reproject function to use. Defaults to 'interp',
+                but can also be 'exact' or 'adaptive'
             overwrite: Whether to overwrite or not
         """
 
@@ -59,6 +62,7 @@ class PSFMatchingStep:
         self.procs = procs
         self.in_step_ext = in_step_ext
         self.target_bands = target_bands
+        self.reproject_func = reproject_func
         self.overwrite = overwrite
 
     def do_step(self):
@@ -176,9 +180,12 @@ class PSFMatchingStep:
         else:
             output_grid = None
 
-        do_jwst_convolution(
-            file, output_file, file_kernel=kernel_file, output_grid=output_grid
-        )
+        do_jwst_convolution(file,
+                            output_file,
+                            file_kernel=kernel_file,
+                            output_grid=output_grid,
+                            reproject_func=self.reproject_func,
+                            )
 
         # Put in BMAJ header keywords for Gaussian convolves
         if "gauss" in target_band.lower():


### PR DESCRIPTION
This PR allows more control over the reproject functions used within various steps. By default, it's reproject_interp (the previous version), but can now be set to reproject_exact and reproject_adaptive. In practice, I'm not seeing any differences swapping to the _exact version, but YMMV