### PR TITLE
Include kernel generation scripts in docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+1.1.1 (Unreleased)
+==================
+
+- Include links to Francesco Belfiore's kernel generation repository in the docs
+
 1.1.0 (2024-03-04)
 ==================
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ and will be passed to the step. This is not necessarily true for each
 JWST pipeline step, for those we recommend looking at 
 [the online docs](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/main.html#pipelines)
 
+### Useful additional resources
+
+* If you'd like to generate convolution kernels easily, [this repository](https://github.com/francbelf/jwst_kernels) 
+  will do that for you
+
 ### Credits
 
 PJPipe has been developed by the [PHANGS Team](phangs.org), with major contributions from:

--- a/docs/steps/anchoring.rst
+++ b/docs/steps/anchoring.rst
@@ -5,6 +5,9 @@ AnchoringStep
 This step will anchor images to an external reference level, and then will internally match other bands to this
 externally matched band. You will need to provide convolution kernels and images.
 
+If you want to generate a kernel that can feed directly into this step, please see
+`this repository <https://github.com/francbelf/jwst_kernels>`_.
+
 ---
 API
 ---

--- a/docs/steps/psf_matching.rst
+++ b/docs/steps/psf_matching.rst
@@ -5,6 +5,9 @@ PSFMatchingStep
 This step will convolve mosaics to a common resolution. You'll need to supply the convolution kernels, but this will
 do the rest.
 
+If you want to generate a kernel that can feed directly into this step, please see
+`this repository <https://github.com/francbelf/jwst_kernels>`_.
+
 ---
 API
 ---


### PR DESCRIPTION
This PR adds links in relevant places in the docs to Francesco's kernel generation scripts. As suggested by Adam