### PR TITLE
Recombine lyot and main science in level_match

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 1.1.1 (Unreleased)
 ==================
 
+- Added ``recombine_lyot`` option to ``level_match_step``, which allows for recombining
+  the lyot coronagraph into the main MIRI science chip before matching between mosaic tiles
+- Tidied up ``level_match_step`` to make more modular and functional
 - Fix bug in ``astrometric_align_step`` if first pass of alignment succeeds but second
   fails
 - Add cross-correlation option to ``get_wcs_adjust_step``, which uses ``spacepylot``

--- a/docs/steps/level_match.rst
+++ b/docs/steps/level_match.rst
@@ -8,6 +8,10 @@ overlapping pair find the median per-pixel difference, and minimize for that. We
 for dithers within a mosaic tile, and then for all mosaic tiles (creating stacked images). This maximises overlaps
 between mosaic tiles and produces better results from our testing.
 
+For MIRI imaging, there is an optional ``recombine_lyot`` parameter. If you've used the ``lyot_separate`` step then
+this will match the coronagraph and main science chip and recombine them before any potential matching between
+different tiles in the mosaic.
+
 N.B. This should be run once you have good local astrometry, and before you do
 :doc:`MultiTileDestripeStep <multi_tile_destripe>`.
 

--- a/pjpipe/pipeline.py
+++ b/pjpipe/pipeline.py
@@ -624,6 +624,7 @@ class PJPipeline:
                                 out_dir=out_dir,
                                 step_ext=in_step_ext,
                                 procs=self.procs,
+                                band=band,
                                 **kws,
                             )
                             step_result = level_match.do_step()


### PR DESCRIPTION
This PR adds a setting to level_match that allows for recombination of the coronagraph and the main chip before matching between mosaic tiles. Initial testing shows this doesn't make a difference to the final mosaic, but is the first step in a more major change to allow for gradients across tiles, rather than just a DC offset to be fitted. Also comes with some code rearrangement to make things a bit more modular and cleaner