### PR TITLE
Add plane fitting to level_match_step.py

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -15,9 +15,10 @@ jobs:
     strategy:
       matrix:
         # Versions listed at https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-        python-version: ["3.9",
-                         "3.10",
-                         "3.11",
+        python-version: [
+          "3.10",
+          "3.11",
+          "3.12",
         ]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install build
         run: python -m pip install build
       - name: Build sdist

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,17 @@
 1.1.1 (Unreleased)
 ==================
 
+- Added ``combine_nircam_short`` option in ``level_match_step``, which will match levels
+  between the four NIRCam short imaging chips before doing matching between mosaic tiles
+- ``lv2_step`` will now propagate through individual exposure offset times from backgrounds,
+  which is necessary for selecting a reference image in ``level_match_step``
+- Added ``fit_type`` option to ``level_match_step`` for every option, which allows for
+  plane fitting in the level matching in a modular way
+- ``level_match_step`` fitting method has been changed to resemble the iterative Montage method,
+  which is necessary for plane fitting
+- ``reproject_image`` in ``utils`` can now also reproject error arrays
+- ``make_stacked_image`` in ``utils`` can now also reproject the error and readnoise maps
+- Exposed ``auto_rotate`` in ``make_stacked_image`` in ``utils``
 - Added prefilter option to ``get_wcs_adjust``, which uses constrained diffusion to remove large-scale structure
 - Added ``recombine_lyot`` option to ``level_match_step``, which allows for recombining
   the lyot coronagraph into the main MIRI science chip before matching between mosaic tiles
@@ -12,9 +23,11 @@
   or ``reproject_adaptive``. For MIRI, ``reproject_exact`` may work better. This applies to ``anchoring_step``,
   ``astrometric_align_step``, ``level_match_step``, ``multi_tile_destripe_step``, ``psf_matching_step``, and
   ``release_step``
+- Fix bug for lv1 hanging on newer Macbooks
 - Fix bug for parameters with 'pix' in getting picked up like numbers of pixels
 - Updated PHANGS Cy3 config
 - Include links to Francesco Belfiore's kernel generation repository in the docs
+- Updated various package requirements
 
 1.1.0 (2024-03-04)
 ==================

--- a/config/2107/mac.toml
+++ b/config/2107/mac.toml
@@ -1,5 +1,5 @@
 crds_path = '/Users/thomaswilliams/Documents/phangs/jwst/crds/'
-raw_dir = '/Users/thomaswilliams/Documents/phangs/jwst/jwst_raw/'
+raw_dir = '/Users/thomaswilliams/Documents/phangs/jwst/jwst_raw/archive_20240402'
 reprocess_dir = '/Users/thomaswilliams/Documents/phangs/jwst/jwst_phangs_reprocessed/'
 alignment_dir = '/Users/thomaswilliams/PycharmProjects/pjpipe/config/2107/alignment/2107/alignment/'
 webb_psf_data = '/Users/thomaswilliams/Documents/phangs/jwst/webb_psf_data/'

--- a/config/2107/run_reprocessing.py
+++ b/config/2107/run_reprocessing.py
@@ -5,8 +5,8 @@ import pjpipe
 this_dir = os.path.dirname(os.path.realpath(__file__))
 
 config_file = os.path.join(this_dir, "config.toml")
-local_file = os.path.join(this_dir, "astronode.toml")
-# local_file = os.path.join(this_dir, "mac.toml")
+# local_file = os.path.join(this_dir, "astronode.toml")
+local_file = os.path.join(this_dir, "mac.toml")
 
 # We need to set CRDS path
 local = pjpipe.load_toml(local_file)

--- a/config/3707/config.toml
+++ b/config/3707/config.toml
@@ -1,19 +1,19 @@
 # List of targets
 targets = [
-    'ngc2997'
-#    'ngc1511',
-#    'ngc2283',
-#    'ngc1637',
-#    'ngc1792',
-#    'ngc1808',
-#    # 'ngc1068', # run separately
-#    'ic5273',
-#    'ngc7456',
-#    'ngc1809',
-#    'ngc1546',
-#    'ngc1559',
-#    'ngc2090',
-#    'ngc1097',
+    'ngc1511',
+    'ngc2283',
+    'ngc1637',
+    'ngc1792',
+    'ngc1808',
+    # 'ngc1068', # run separately
+    'ic5273',
+    'ngc7456',
+    'ngc1809',
+    'ngc1546',
+    'ngc1559',
+    'ngc2090',
+    'ngc1097',
+    'ngc2566',
 ]
 
 # Version for the reprocessing
@@ -21,15 +21,15 @@ version = 'v0p1p6'
 
 # Bands to consider
 bands = [
-#    'F150W',
-#    'F187N',
-#    'F200W',
-#    'F300M',
-#    'F335M',
+    'F150W',
+    'F187N',
+    'F200W',
+    'F300M',
+    'F335M',
     'F770W',
-#    'F2100W',
+    'F2100W',
     'F770W_bgr',
-#    'F2100W_bgr',
+    'F2100W_bgr',
 ]
 
 # Steps. These can/should be different
@@ -43,17 +43,18 @@ steps = [
     'lv2',
     'get_wcs_adjust',
     'apply_wcs_adjust',
+#    'lyot_mask.miri',
     'lyot_separate.miri',
     'level_match',
-#    'multi_tile_destripe.nircam',
+    'multi_tile_destripe.nircam',
 #    'psf_model',  # TODO
     'lv3',
     'astrometric_catalog.miri',
     'astrometric_align',
-#    'anchoring',
-#    'psf_matching',
-#    'release',
-#    'regress_against_previous',
+    'anchoring',
+    'psf_matching',
+    'release',
+    'regress_against_previous',
 ]
 
 # Parameters for downloading data. This just downloads
@@ -92,11 +93,10 @@ jwst_parameters.bkg_subtract.sigma = 1.5
 
 [parameters.get_wcs_adjust]
 
-method.nircam = "tweakreg"
-method.miri = "tweakreg"
+method = "tweakreg"
 
 bands = [
-#    'F300M',
+    'F300M',
     'F770W',
 ]
 
@@ -105,8 +105,8 @@ group_dithers = [
     'miri',
 ]
 
-custom_catalog_function = 'constrained_diffusion'
-custom_catalog_function_kwargs = {roundlo = 0.0, roundhi = 0.1, sharplo = 0.6, sharphi = 1.1}
+#custom_catalog_function = 'constrained_diffusion'
+#custom_catalog_function_kwargs = {roundlo = 0.0, roundhi = 0.1, sharplo = 0.6, sharphi = 1.1}
 
 [parameters.get_wcs_adjust.tweakreg_parameters]
 
@@ -154,6 +154,16 @@ do_large_scale = true
 large_scale_filter_extend_mode = "reflect"
 
 [parameters.level_match]
+
+fit_type_dithers.nircam = "level"
+fit_type_mosaic_tiles.nircam = "level"
+
+fit_type_dithers.miri = "level"
+fit_type_recombine_lyot = "level"
+fit_type_mosaic_tiles.miri = "level"
+
+recombine_lyot = true
+combine_nircam_short = true
 do_sigma_clip = false
 weight_method = 'rms'
 
@@ -179,8 +189,8 @@ save_results = true
 
 # Skip MIRI wavelengths, since we have already
 # solved for this
-skip.F770W = false
-skip.F2100W = false
+skip.F770W = true
+skip.F2100W = true
 
 # align_to_gaia = false # no longer a tweakreg parameter
 starfinder = 'iraf'
@@ -272,7 +282,7 @@ ngc1808 = 'Gaia_DR3_ngc1808.fits'
 ngc1792 = 'Gaia_DR3_ngc1792.fits'
 ngc1637 = 'Gaia_DR3_ngc1637.fits'
 ngc2283 = 'Gaia_DR3_ngc2283.fits'
-ngc2997 = 'ngc2997_sourcecat.fits'
+ngc2566 = 'Gaia_DR3_ngc2566.fits'
 
 # Initial pass to get decent shifts for absolute astrometry
 [parameters.astrometric_align.tweakreg_parameters.iteration1]

--- a/config/3707/mac.toml
+++ b/config/3707/mac.toml
@@ -1,5 +1,5 @@
 crds_path = '/Users/thomaswilliams/Documents/phangs/jwst/crds/'
-crds_context = 'jwst_1210.pmap'
+crds_context = 'jwst_1238.pmap'
 raw_dir = '/Users/thomaswilliams/Documents/phangs/jwst/jwst_raw/3707/'
 reprocess_dir = '/Users/thomaswilliams/Documents/phangs/jwst_3707/reprocessing/'
 alignment_dir = '/Users/thomaswilliams/PycharmProjects/pjpipe/config/3707/alignment/'

--- a/docs/steps/level_match.rst
+++ b/docs/steps/level_match.rst
@@ -4,13 +4,26 @@ LevelMatchStep
 
 This step matches relative levels between tiles, using an algorithm very similar to
 `Montage <http://montage.ipac.caltech.edu/>`_. We reproject tiles to a common astrometric grid, and then for each
-overlapping pair find the median per-pixel difference, and minimize for that. We do this in a two-pass process, firstly
-for dithers within a mosaic tile, and then for all mosaic tiles (creating stacked images). This maximises overlaps
-between mosaic tiles and produces better results from our testing.
+overlapping pair find the median per-pixel difference, and minimize for that. We do this in a two (or three)-pass
+process, firstly for dithers within a mosaic tile, then optionally for main science chip and lyot coronagraph,
+optionally between the four NIRCam short chips, and then for all mosaic tiles (creating stacked images). This maximises
+overlaps between mosaic tiles and produces better results from our testing.
 
 For MIRI imaging, there is an optional ``recombine_lyot`` parameter. If you've used the ``lyot_separate`` step then
 this will match the coronagraph and main science chip and recombine them before any potential matching between
 different tiles in the mosaic.
+
+For NIRCam short imaging, there is an optional ``combine_nircam_short`` parameter. This will match levels between the
+four NIRCam short chips and then will treat as one single image going into the final mosaic level matching stage.
+
+For each of these three stages, you can match either with a simple constant offset ("level") or with a plane
+("level+match"). This can be controlled separately for each stage (``fit_type_dithers``, ``fit_type_recombine_lyot``,
+``fit_type_combine_nircam_short``, ``fit_type_mosaic_tiles``). By default, everything will just fit a constant offset.
+
+When matching between mosaic tiles, we select a reference image that we deem to be the most flat, and will adjust any
+corrections relative to that. If you are using observations with dedicated backgrounds (as defined by
+:doc:`Lv2Step <lv2>`, then it will select the image closest in time to the backgrounds. If not, it will use the image
+with the most overlapping image pairs.
 
 N.B. This should be run once you have good local astrometry, and before you do
 :doc:`MultiTileDestripeStep <multi_tile_destripe>`.

--- a/pjpipe/level_match/level_match_step.py
+++ b/pjpipe/level_match/level_match_step.py
@@ -10,11 +10,16 @@ import shutil
 import warnings
 from functools import partial
 
+import astropy.units as u
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+from astropy.coordinates import SkyCoord
+from astropy.io import fits
 from astropy.stats import sigma_clipped_stats
+from astropy.wcs import WCS
 from reproject.mosaicking import find_optimal_celestial_wcs
+from scipy.optimize import minimize
 from stdatamodels.jwst import datamodels
 from threadpoolctl import threadpool_limits
 from tqdm import tqdm
@@ -31,6 +36,11 @@ ALLOWED_REPROJECT_FUNCS = [
     "exact",
 ]
 
+ALLOWED_FIT_TYPES = [
+    "level",
+    "level+slope",
+]
+
 matplotlib.use("agg")
 matplotlib.rcParams['mathtext.fontset'] = 'stix'
 matplotlib.rcParams['font.family'] = 'STIXGeneral'
@@ -40,18 +50,25 @@ log = logging.getLogger("stpipe")
 log.addHandler(logging.NullHandler())
 
 
-def get_dithers(files):
+def get_dithers(files,
+                combine_nircam_short=False,
+                ):
     """Get unique dithers from a list of files
 
     Args:
         files: List of input files
+        combine_nircam_short: Whether to drop the chip number from
+            NIRCam short observations. Defaults to False
     """
 
     # Split these into dithers per-chip
     dithers = []
     for file in files:
         file_split = os.path.split(file)[-1].split("_")
-        dithers.append("_".join(file_split[:2]) + "_*_" + file_split[-2])
+        dither_str = "_".join(file_split[:2]) + "_*_" + file_split[-2]
+        if combine_nircam_short:
+            dither_str = dither_str[:-1] + "*"
+        dithers.append(dither_str)
     dithers = np.unique(dithers)
     dithers.sort()
 
@@ -60,14 +77,216 @@ def get_dithers(files):
 
 def apply_subtraction(im,
                       delta,
+                      fit_type="level",
+                      ref_ra=0,
+                      ref_dec=0,
+                      ref_wcs=None,
+                      ref_shape=None,
                       ):
-    """Apply subtraction to the image."""
+    """Apply subtraction to the image.
 
-    zero_idx = np.where(im.data == 0)
-    im.data -= delta
+    Args:
+        im: Input datamodel
+        delta: Coefficients to subtract from the image
+        fit_type: Type of fitting we've done. Options
+            are 'level' (the default, just fits a
+            single offset), and 'level+slope' (which will
+            fit a plane)
+        ref_ra: The reference RA point for the fits. Defaults to 0
+        ref_dec: The reference Dec point for the fits. Defaults to 0
+        ref_wcs: Reference WCS for the fits, since we do in pixel space.
+            If None, will assume this is the WCS for the image, which is
+            likely incorrect
+        ref_shape: Shape for the reference WCS, since we do the fits in
+            pixel space. If None, will assume the image shape, which is
+            likely incorrect
+    """
+
+    zero_idx = im.data == 0
+
+    if fit_type == "level":
+        im.data -= delta[0]
+    elif fit_type == "level+slope":
+
+        # Here, pull out the WCS and use this to convert the delta
+        # coefficients to a slope for valid pixels
+        w = copy.deepcopy(im.meta.wcs.to_fits_sip())
+        wcs = WCS(w)
+
+        ii, jj = np.indices(im.data.shape, dtype=float)
+
+        if ref_wcs is None:
+            ref_wcs = copy.deepcopy(wcs)
+        if ref_shape is None:
+            ref_shape = copy.deepcopy(im.data.shape)
+
+        # This is a little fiddly, we need to convert to the proper reference frame and then map pixel
+        # coordinates
+        frame_coords = wcs.pixel_to_world(jj, ii)
+
+        ii_ref, jj_ref = np.indices(ref_shape)
+        ref_coords = ref_wcs.pixel_to_world(jj_ref, ii_ref)
+
+        # Convert the input world coordinates to the frame of the output world
+        # coordinates.
+        frame_coords = frame_coords.transform_to(ref_coords.frame)
+
+        # Compute the pixel positions in the *output* image of the pixels
+        # from the *input* image.
+        jj, ii = ref_wcs.world_to_pixel(frame_coords)
+
+        # Finally, subtract off the reference
+        ref_j, ref_i = get_x_y_values(ref_wcs, ref_ra, ref_dec)
+        jj -= ref_j
+        ii -= ref_i
+
+        delta_plane = delta[0] * jj + delta[1] * ii + delta[2]
+
+        im.data -= delta_plane
+
+    else:
+        raise ValueError(f"fit_type {fit_type} not known, should be one of {ALLOWED_FIT_TYPES}")
+
     im.data[zero_idx] = 0
 
     return im
+
+
+def plane(x, y, params):
+    """Define a plane of the form
+
+    params[0] * x + params[1] * y + params[2]
+
+    Args:
+        x: x coordinates
+        y: y coordinates
+        params: Parameters for the plane
+    """
+
+    a = params[0]
+    b = params[1]
+    c = params[2]
+    z = a * x + b * y + c
+    return z
+
+
+def plane_resid(params,
+                points,
+                err=None,
+                return_sum=True,
+                ):
+    """Calculates the difference between a plane and input points
+
+    Args:
+        params: Parameters for the plane
+        points: (x, y, z) coordinates measured
+        err: Error on each z-point. Defaults to None
+        return_sum: Whether to return the sum or all
+            the individual values. Defaults to True
+    """
+
+    plane_z = plane(points[:, 0], points[:, 1], params)
+    diff = points[:, 2] - plane_z
+
+    if err is None:
+        result = diff ** 2
+    else:
+        result = diff ** 2 / err ** 2
+
+    # Scale chisq using sqrt(2N) to account for large number of points
+    result /= np.sqrt(2 * len(points[:, 0]))
+
+    if return_sum:
+        result = np.nansum(result)
+
+    return result
+
+
+def cross(a, b):
+    return [a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0]]
+
+
+def print_delta(file,
+                delta,
+                fit_type="level",
+                ):
+    """Format the delta for the log properly
+
+    Args:
+        file: Filename to apply the delta to
+        delta: Delta coefficients
+        fit_type: Which type of fit to do. See ALLOWED_FIT_TYPES. Defaults to "level"
+    """
+
+    if fit_type == "level":
+        log.info(f"{file}, delta={delta[0]:.2e}")
+    elif fit_type == "level+slope":
+
+        # Format pos/negs correctly in the string
+        if delta[1] < 0:
+            sign_dec = "-"
+        else:
+            sign_dec = "+"
+        if delta[2] < 0:
+            sign_dc = "-"
+        else:
+            sign_dc = "+"
+
+        log.info(f"{file}, plane={delta[0]:.2e} * x (pix) "
+                 f"{sign_dec} {np.abs(delta[1]):.2e} * y (pix) "
+                 f"{sign_dc} {np.abs(delta[2]):.2e}")
+    else:
+        raise ValueError(f"fit_type should be one of {ALLOWED_FIT_TYPES}")
+
+
+def get_ra_dec_values(wcs,
+                      jj,
+                      ii,
+                      units=u.arcsec,
+                      return_coords=False,
+                      ):
+    """Get RA/Dec values, given an input structure
+
+    Args:
+        wcs: Input WCS
+        jj: j coords
+        ii: i coords
+        units: Reference unit. Defaults to u.arcsec
+        return_coords: If True, will return SkyCoords.
+            Otherwise will convert
+    """
+
+    coords = wcs.pixel_to_world(jj, ii)
+
+    if return_coords:
+        return coords
+
+    ra = coords.ra.to(units).value
+    dec = coords.dec.to(units).value
+
+    return ra, dec
+
+
+def get_x_y_values(wcs,
+                   ras,
+                   decs,
+                   units=u.arcsec,
+                   ):
+    """Get x/y values, given an input structure
+
+    Args:
+        wcs: Input WCS
+        ras: RAs
+        decs: Decs
+        units: Reference unit. Defaults to u.arcsec
+    """
+
+    c = SkyCoord(ras * units, decs * units)
+    x, y = wcs.world_to_pixel(c)
+
+    return x, y
 
 
 class LevelMatchStep:
@@ -78,7 +297,12 @@ class LevelMatchStep:
             step_ext,
             procs,
             band,
+            fit_type_dithers="level",
+            fit_type_recombine_lyot="level",
+            fit_type_combine_nircam_short="level",
+            fit_type_mosaic_tiles="level",
             recombine_lyot=False,
+            combine_nircam_short=False,
             do_local_subtraction=True,
             sigma=3,
             npixels=3,
@@ -113,8 +337,25 @@ class LevelMatchStep:
                 into the step
             procs: Number of parallel processes to run
             band: JWST band
+            fit_type_dithers: What kind of fit to do to match levels between
+                dithers in a single mosaic tile. Options are 'level' (the default,
+                just fits a single offset), and 'level+slope' (which will fit a plane)
+            fit_type_recombine_lyot: What kind of fit to do to match levels between
+                science and lyot in a single mosaic tile. Options are 'level'
+                (the default, just fits a single offset), and 'level+slope' (which will
+                fit a plane)
+            fit_type_combine_nircam_short: What kind of fit to do to match levels between
+                the four NIRCam short chips. Options are 'level' (the default, just fits
+                a single offset), and 'level+slope' (which will fit a plane)
+            fit_type_mosaic_tiles: What kind of fit to do to match levels between
+                mosaic tiles. Options are 'level' (the default, just fits a single offset),
+                and 'level+slope' (which will fit a plane)
             recombine_lyot: If True, will recombine the lyot coronagraph
-                into the main chip after the initial round of level matching
+                into the main chip after the initial round of level matching.
+                This will force the main science chip to have a 0 correction,
+                as the lyot seems to be more wobbly. Defaults to False
+            combine_nircam_short: Whether to combine the four NIRCam short
+                chips before matching in a mosaic. Defaults to False
             do_local_subtraction: Whether to do a sigma-clipped local median
                 subtraction. Defaults to True
             sigma: Sigma for sigma-clipping. Defaults to 3
@@ -141,13 +382,30 @@ class LevelMatchStep:
 
         if reproject_func not in ALLOWED_REPROJECT_FUNCS:
             raise ValueError(f"reproject_func should be one of {ALLOWED_REPROJECT_FUNCS}")
+        if fit_type_dithers not in ALLOWED_FIT_TYPES:
+            raise ValueError(f"fit_type_dithers should be one of {ALLOWED_FIT_TYPES}")
+        if fit_type_recombine_lyot not in ALLOWED_FIT_TYPES:
+            raise ValueError(f"fit_type_recombine_lyot should be one of {ALLOWED_FIT_TYPES}")
+        if fit_type_combine_nircam_short not in ALLOWED_FIT_TYPES:
+            raise ValueError(f"fit_type_combine_nircam_short should be one of {ALLOWED_FIT_TYPES}")
+        if fit_type_mosaic_tiles not in ALLOWED_FIT_TYPES:
+            raise ValueError(f"fit_type_mosaic_tiles should be one of {ALLOWED_FIT_TYPES}")
+
+        if do_local_subtraction and fit_type_dithers not in ["level"]:
+            log.warning("Cannot do local subtraction for methods beyond simple offset. Switching off")
+            do_local_subtraction = False
 
         self.in_dir = in_dir
         self.out_dir = out_dir
         self.step_ext = step_ext
         self.procs = procs
         self.band = band
+        self.fit_type_dithers = fit_type_dithers
+        self.fit_type_recombine_lyot = fit_type_recombine_lyot
+        self.fit_type_combine_nircam_short = fit_type_combine_nircam_short
+        self.fit_type_mosaic_tiles = fit_type_mosaic_tiles
         self.recombine_lyot = recombine_lyot
+        self.combine_nircam_short = combine_nircam_short
         self.do_local_subtraction = do_local_subtraction
         self.sigma = sigma
         self.npixels = npixels
@@ -196,33 +454,77 @@ class LevelMatchStep:
         )
         files.sort()
 
-        dithers = get_dithers(files)
+        dithers = get_dithers(files,
+                              )
 
-        success = self.match_dithers(dithers)
+        success = self.match_dithers(dithers,
+                                     fit_type=self.fit_type_dithers,
+                                     )
         if not success:
             log.warning("Failures detected level matching between individual dithers")
             return False
 
         if self.recombine_lyot:
-            success = self.match_lyot_science(dithers)
-            if not success:
-                log.warning("Failures detected level matching between individual dithers")
-                return False
 
-            # Redo the dithers, since now the "l" and "s" will have potentially been dropped
-            files = glob.glob(
-                os.path.join(
-                    self.out_dir,
-                    f"*_{self.step_ext}.fits",
+            # First, check we're in MIRI mode
+            band_type = get_band_type(self.band)
+
+            if band_type in ["miri"]:
+
+                success = self.match_lyot_science(dithers,
+                                                  fit_type=self.fit_type_recombine_lyot,
+                                                  )
+                if not success:
+                    log.warning("Failures detected level matching between lyot and main science")
+                    return False
+
+                # Redo the dithers, since now the "l" and "s" will have potentially been dropped
+                files = glob.glob(
+                    os.path.join(
+                        self.out_dir,
+                        f"*_{self.step_ext}.fits",
+                    )
                 )
-            )
-            files.sort()
+                files.sort()
 
-            # Split these into dithers per-chip
-            dithers = get_dithers(files)
+                # Split these into dithers per-chip
+                dithers = get_dithers(files)
+
+        if self.combine_nircam_short:
+
+            # First, check we're in NIRCam short mode
+            band_type, short_long_nircam = get_band_type(self.band,
+                                                         short_long_nircam=True,
+                                                         )
+
+            if short_long_nircam in ["nircam_short"]:
+
+                success = self.match_nircam_short(dithers,
+                                                  fit_type=self.fit_type_combine_nircam_short,
+                                                  )
+
+                if not success:
+                    log.warning("Failures detected level matching between individual dithers")
+                    return False
+
+                # Redo the dithers, since now we'll combine the 4 imaging chips for the short NIRCam
+                files = glob.glob(
+                    os.path.join(
+                        self.out_dir,
+                        f"*_{self.step_ext}.fits",
+                    )
+                )
+                files.sort()
+
+                # Split these into dithers per-chip
+                dithers = get_dithers(files,
+                                      combine_nircam_short=True,
+                                      )
 
         if len(dithers) > 1:
-            success = self.match_mosaic_tiles(dithers)
+            success = self.match_mosaic_tiles(dithers,
+                                              fit_type=self.fit_type_mosaic_tiles,
+                                              )
             if not success:
                 log.warning("Failures detected level matching between mosaic tiles")
                 return False
@@ -234,18 +536,24 @@ class LevelMatchStep:
 
     def match_dithers(self,
                       dithers,
+                      fit_type="level",
                       ):
         """Match levels between the dithers in each mosaic tile
 
         Args:
             dithers: List of dither groups
+            fit_type: Which type of fit to do. See ALLOWED_FIT_TYPES. Defaults to "level"
         """
+
+        if fit_type not in ALLOWED_FIT_TYPES:
+            raise ValueError(f"fit_type should be one of {ALLOWED_FIT_TYPES}")
 
         # Ensure we're not wasting processes
         procs = np.nanmin([self.procs, len(dithers)])
 
-        deltas, dither_files = self.get_per_dither_delta(
+        deltas, dither_files, ref_ras, ref_decs, optimal_wcses, optimal_shapes = self.get_per_dither_delta(
             dithers=dithers,
+            fit_type=fit_type,
             procs=procs,
         )
 
@@ -253,6 +561,10 @@ class LevelMatchStep:
         for idx in range(len(deltas)):
             deltas_idx = copy.deepcopy(deltas[idx])
             dither_files_idx = copy.deepcopy(dither_files[idx])
+            ref_ra = copy.deepcopy(ref_ras[idx])
+            ref_dec = copy.deepcopy(ref_decs[idx])
+            optimal_wcs = copy.deepcopy(optimal_wcses[idx])
+            optimal_shape = copy.deepcopy(optimal_shapes[idx])
 
             # If we're including a local subtraction, do it here
             if self.do_local_subtraction:
@@ -292,24 +604,37 @@ class LevelMatchStep:
                     short_file,
                 )
                 delta = copy.deepcopy(deltas_idx[i])
-                log.info(f"{short_file}, delta={delta + local_delta:.2f}")
+                delta[-1] += local_delta
+
+                print_delta(file=short_file,
+                            delta=delta,
+                            fit_type=fit_type,
+                            )
 
                 with datamodels.open(dither_file) as im:
-                    im = apply_subtraction(im, delta + local_delta)
+                    im = apply_subtraction(im,
+                                           delta,
+                                           fit_type=fit_type,
+                                           ref_ra=ref_ra,
+                                           ref_dec=ref_dec,
+                                           ref_wcs=optimal_wcs,
+                                           ref_shape=optimal_shape,
+                                           )
                     im.save(out_file)
                 del im
 
         return True
 
     def match_lyot_science(self,
-                           dithers):
-        """Match levels between each individual lyot/main science chip, and recombine"""
+                           dithers,
+                           fit_type="level",
+                           ):
+        """Match levels between each individual lyot/main science chip, and recombine
 
-        # First, check we're in MIRI mode
-        band_type = get_band_type(self.band)
-
-        if band_type not in ["miri"]:
-            return True
+        Args:
+            dithers: List of dithers
+            fit_type: Which type of fit to do. See ALLOWED_FIT_TYPES. Defaults to "level"
+        """
 
         log.info("Matching levels between lyot and main chip and recombining")
 
@@ -352,6 +677,7 @@ class LevelMatchStep:
                         partial(
                             self.parallel_match_lyot_science,
                             stacked_dir=stacked_dir,
+                            fit_type=fit_type,
                         ),
                         combined_miri_dithers,
                     ),
@@ -375,13 +701,90 @@ class LevelMatchStep:
 
         return True
 
+    def match_nircam_short(self,
+                           dithers,
+                           fit_type="level",
+                           ):
+        """Match levels between the NIRCam short chips
+
+        Args:
+            dithers: List of dithers
+            fit_type: Which type of fit to do. See ALLOWED_FIT_TYPES. Defaults to "level"
+        """
+
+        log.info("Matching levels between NIRCam shorts")
+
+        # From the individually corrected images
+        # get a stacked image
+        stacked_dir = self.out_dir + "_stacked"
+        if not os.path.exists(stacked_dir):
+            os.makedirs(stacked_dir)
+
+        procs = np.nanmin([self.procs, len(dithers)])
+
+        # We now want to group up the four NIRCam imaging chips
+        combined_nircam_dithers = []
+        for dither in dithers:
+            combined_nircam_dithers.append(dither[:-1])
+        combined_nircam_dithers = np.unique(combined_nircam_dithers)
+
+        if len(combined_nircam_dithers) == 0:
+            log.info("No NIRCam shorts found. Returning")
+            return True
+
+        successes = self.make_stacked_images(
+            dithers=dithers,
+            stacked_dir=stacked_dir,
+            procs=procs,
+        )
+
+        if not np.all(successes):
+            log.warning("Failures detected making stacked images")
+            return False
+
+        procs = np.nanmin([self.procs, len(combined_nircam_dithers)])
+
+        successes = []
+
+        with mp.get_context("fork").Pool(procs) as pool:
+            for success in tqdm(
+                    pool.imap_unordered(
+                        partial(
+                            self.parallel_match_nircam_short,
+                            stacked_dir=stacked_dir,
+                            fit_type=fit_type,
+                        ),
+                        combined_nircam_dithers,
+                    ),
+                    total=len(combined_nircam_dithers),
+                    desc="Matching NIRCAM short chips",
+                    ascii=True,
+                    disable=True,
+            ):
+                successes.append(success)
+
+            pool.close()
+            pool.join()
+            gc.collect()
+
+        # Remove the stacked images
+        shutil.rmtree(stacked_dir)
+
+        if not np.all(successes):
+            log.warning("Failures detected matching NIRCam short chips")
+            return False
+
+        return True
+
     def match_mosaic_tiles(self,
                            dithers,
+                           fit_type="level",
                            ):
         """Match levels between each mosaic tile
 
         Args:
             dithers: List of dither groups
+            fit_type: Which type of fit to do. See ALLOWED_FIT_TYPES. Defaults to "level"
         """
 
         log.info("Matching levels between mosaic tiles")
@@ -408,21 +811,61 @@ class LevelMatchStep:
         stacked_files = glob.glob(
             os.path.join(stacked_dir, f"*_{self.step_ext}.fits")
         )
+        stacked_files.sort()
+
+        # From these files, select a reference image based on the closest background,
+        # if possible
+        bgr_times = np.zeros(len(stacked_files))
+        bgr_times[bgr_times == 0] = np.nan
+
+        for i, f in enumerate(stacked_files):
+            with fits.open(f) as hdu:
+                if "DT_BGR" in hdu[0].header:
+                    bgr_times[i] = float(hdu[0].header["DT_BGR"])
+
+        if np.all(np.isnan(bgr_times)):
+            # If we don't have any background times, let it select automatically
+            ref_idx = 0
+            log.info("Will use first image as the reference image")
+        else:
+            # Get the one closest in time to the backgrounds
+            ref_idx = np.nanargmin(np.abs(bgr_times))
+
+            # If it's selected a lyot image, force it to be the science
+            tidy_file = os.path.split(stacked_files[ref_idx])[-1]
+            full_file = stacked_files[ref_idx]
+
+            if "mirimagel" in tidy_file:
+                tidy_file = tidy_file.replace("mirimagel", "mirimages")
+                full_file = full_file.replace("mirimagel", "mirimages")
+                ref_idx = stacked_files.index(full_file)
+
+            log.info(f"Will use {tidy_file} as the reference image")
+
         (
             delta_matrix,
             npix_matrix,
             rms_matrix,
             lin_size_matrix,
+            valid_matrix,
+            optimal_wcs,
+            optimal_shape,
+            ref_ra,
+            ref_dec,
         ) = self.calculate_delta(
             stacked_files,
-            procs=procs,
+            fit_type=fit_type,
             stacked_image=True,
+            procs=procs,
         )
         deltas = self.find_optimum_deltas(
             delta_mat=delta_matrix,
             npix_mat=npix_matrix,
             rms_mat=rms_matrix,
             lin_size_mat=lin_size_matrix,
+            valid_mat=valid_matrix,
+            fit_type=fit_type,
+            ref_idx=ref_idx,
         )
 
         # Subtract the per-dither delta, do in place
@@ -436,12 +879,21 @@ class LevelMatchStep:
             )
             dither_files.sort()
 
-            for dither_file in dither_files:
-                short_dither_file = os.path.split(dither_file)[-1]
-                log.info(f"{short_dither_file}, delta={delta:.2f}")
+            print_delta(file=short_stack_file,
+                        delta=delta,
+                        fit_type=fit_type,
+                        )
 
+            for dither_file in dither_files:
                 with datamodels.open(dither_file) as im:
-                    im = apply_subtraction(im, delta)
+                    im = apply_subtraction(im,
+                                           delta,
+                                           fit_type=fit_type,
+                                           ref_ra=ref_ra,  # [idx],
+                                           ref_dec=ref_dec,  # [idx],
+                                           ref_wcs=optimal_wcs,
+                                           ref_shape=optimal_shape,
+                                           )
                     im.save(dither_file)
                 del im
 
@@ -453,12 +905,14 @@ class LevelMatchStep:
     def get_per_dither_delta(
             self,
             dithers,
+            fit_type="level",
             procs=1,
     ):
         """Function to parallelise getting the delta for each observation in a dither sequence
 
         Args:
             dithers: List of dithers to get deltas for
+            fit_type: Which type of fit to do. See ALLOWED_FIT_TYPES. Defaults to "level"
             procs: Number of processes to run simultaneously. Defaults
                 to 1
         """
@@ -467,12 +921,17 @@ class LevelMatchStep:
 
         deltas = []
         dither_files = []
+        ref_ras = []
+        ref_decs = []
+        optimal_wcses = []
+        optimal_shapes = []
 
         with mp.get_context("fork").Pool(procs) as pool:
-            for delta, dither_file in tqdm(
+            for delta, dither_file, ref_ra, ref_dec, optimal_wcs, optimal_shape in tqdm(
                     pool.imap_unordered(
                         partial(
                             self.parallel_per_dither_delta,
+                            fit_type=fit_type,
                         ),
                         dithers,
                     ),
@@ -482,21 +941,27 @@ class LevelMatchStep:
             ):
                 deltas.append(delta)
                 dither_files.append(dither_file)
+                ref_ras.append(ref_ra)
+                ref_decs.append(ref_dec)
+                optimal_wcses.append(optimal_wcs)
+                optimal_shapes.append(optimal_shape)
 
             pool.close()
             pool.join()
             gc.collect()
 
-        return deltas, dither_files
+        return deltas, dither_files, ref_ras, ref_decs, optimal_wcses, optimal_shapes
 
     def parallel_per_dither_delta(
             self,
             dither,
+            fit_type="level",
     ):
         """Function to parallelise up matching dithers
 
         Args:
             dither: Input dither
+            fit_type: Which type of fit to do. See ALLOWED_FIT_TYPES. Defaults to "level"
         """
 
         dither_files = glob.glob(
@@ -505,7 +970,6 @@ class LevelMatchStep:
                 f"{dither}*_{self.step_ext}.fits",
             )
         )
-
         dither_files.sort()
 
         with threadpool_limits(limits=1, user_api=None):
@@ -514,15 +978,29 @@ class LevelMatchStep:
                 npix_matrix,
                 rms_matrix,
                 lin_size_matrix,
-            ) = self.calculate_delta(dither_files)
+                valid_matrix,
+                optimal_wcs,
+                optimal_shape,
+                ref_ra,
+                ref_dec,
+            ) = self.calculate_delta(dither_files,
+                                     fit_type=fit_type,
+                                     )
+
+        # If we're in a weird edge case where we only have one dither, jump out and just return 0s
+        if len(dither_files) > 1:
             deltas = self.find_optimum_deltas(
                 delta_mat=delta_matrix,
                 npix_mat=npix_matrix,
                 rms_mat=rms_matrix,
                 lin_size_mat=lin_size_matrix,
+                valid_mat=valid_matrix,
+                fit_type=fit_type,
             )
+        else:
+            deltas = np.zeros([delta_matrix.shape[0], delta_matrix.shape[-1]])
 
-        return deltas, dither_files
+        return deltas, dither_files, ref_ra, ref_dec, optimal_wcs, optimal_shape
 
     def make_stacked_images(
             self,
@@ -539,7 +1017,7 @@ class LevelMatchStep:
                 Defaults to 1
         """
 
-        log.info("Created stacked images")
+        log.info("Creating stacked images")
 
         with mp.get_context("fork").Pool(procs) as pool:
             successes = []
@@ -590,10 +1068,13 @@ class LevelMatchStep:
         out_name = "_".join(file_name_split)
         out_name = os.path.join(out_dir, out_name)
 
+        # Make the stacked image. Set auto-rotate True to minimize the image shape
         success = make_stacked_image(
             files=files,
             out_name=out_name,
+            additional_hdus="ERR",
             reproject_func=self.reproject_func,
+            auto_rotate=True,
         )
         if not success:
             return False
@@ -603,12 +1084,17 @@ class LevelMatchStep:
     def parallel_match_lyot_science(self,
                                     dither,
                                     stacked_dir,
+                                    fit_type
                                     ):
         """Function to parallelise up combining the lyot back into the main science chip
+
+        Because the lyot seems to behave a little weirdly in its backgrounds from time-to-time,
+        we force the main science correction to be 0 and put that all into the lyot
 
         Args:
             dither: Dither to level match and combine
             stacked_dir: Directory contained stacked images
+            fit_type: Which type of fit to do. See ALLOWED_FIT_TYPES. Defaults to "level"
         """
 
         stacked_files = glob.glob(
@@ -621,16 +1107,25 @@ class LevelMatchStep:
             npix_matrix,
             rms_matrix,
             lin_size_matrix,
+            valid_matrix,
+            optimal_wcs,
+            optimal_shape,
+            ref_ra,
+            ref_dec,
         ) = self.calculate_delta(
             stacked_files,
-            procs=None,
+            fit_type=fit_type,
             stacked_image=True,
+            procs=None,
         )
         lyot_delta, sci_delta = self.find_optimum_deltas(
             delta_mat=delta_matrix,
             npix_mat=npix_matrix,
             rms_mat=rms_matrix,
             lin_size_mat=lin_size_matrix,
+            valid_mat=valid_matrix,
+            fit_type=fit_type,
+            ref_idx=1,  # Since we want to base the correction on the science files
         )
 
         # Subtract the per-dither delta. Since we've sorted, the first is lyot and the second is
@@ -645,7 +1140,11 @@ class LevelMatchStep:
         sci_files.sort()
 
         short_file = short_stack_file.replace("mirimages", "mirimage")
-        log.info(f"{short_file}: science delta={sci_delta:.2f}, lyot delta={lyot_delta:.2f}")
+
+        print_delta(short_file,
+                    lyot_delta,
+                    fit_type=fit_type,
+                    )
 
         for sci_file in sci_files:
             # Get the equivalent lyot file, and the out file (dropping that s/l)
@@ -653,9 +1152,16 @@ class LevelMatchStep:
             out_file = sci_file.replace("mirimages", "mirimage")
 
             with datamodels.open(sci_file) as sci_im, datamodels.open(lyot_file) as lyot_im:
-                # Do the subtractions
-                sci_im = apply_subtraction(sci_im, sci_delta)
-                lyot_im = apply_subtraction(lyot_im, lyot_delta)
+                # Do the subtraction, only needed on the lyot since we force the science correction
+                # to 0
+                lyot_im = apply_subtraction(lyot_im,
+                                            lyot_delta,
+                                            fit_type=fit_type,
+                                            ref_ra=ref_ra,
+                                            ref_dec=ref_dec,
+                                            ref_wcs=optimal_wcs,
+                                            ref_shape=optimal_shape,
+                                            )
 
                 # Force the lyot back into the science
                 sci_im.data[LYOT_I, LYOT_J] = lyot_im.data[LYOT_I, LYOT_J]
@@ -672,9 +1178,84 @@ class LevelMatchStep:
 
         return True
 
+    def parallel_match_nircam_short(self,
+                                    dither,
+                                    stacked_dir,
+                                    fit_type
+                                    ):
+        """Function to parallelise up matching levels between the short NIRCam chips
+
+        Args:
+            dither: Dither to level match and combine
+            stacked_dir: Directory contained stacked images
+            fit_type: Which type of fit to do. See ALLOWED_FIT_TYPES. Defaults to "level"
+        """
+
+        stacked_files = glob.glob(
+            os.path.join(stacked_dir, f"{dither}*_{self.step_ext}.fits")
+        )
+        stacked_files.sort()
+
+        (
+            delta_matrix,
+            npix_matrix,
+            rms_matrix,
+            lin_size_matrix,
+            valid_matrix,
+            optimal_wcs,
+            optimal_shape,
+            ref_ra,
+            ref_dec,
+        ) = self.calculate_delta(
+            stacked_files,
+            fit_type=fit_type,
+            stacked_image=True,
+            procs=None,
+        )
+        deltas = self.find_optimum_deltas(
+            delta_mat=delta_matrix,
+            npix_mat=npix_matrix,
+            rms_mat=rms_matrix,
+            lin_size_mat=lin_size_matrix,
+            valid_mat=valid_matrix,
+            fit_type=fit_type,
+        )
+
+        # Subtract the per-dither delta, do in place
+        for idx, delta in enumerate(deltas):
+            short_stack_file = os.path.split(stacked_files[idx])[-1]
+            dither_files = glob.glob(
+                os.path.join(
+                    self.out_dir,
+                    short_stack_file,
+                )
+            )
+            dither_files.sort()
+
+            print_delta(file=short_stack_file,
+                        delta=delta,
+                        fit_type=fit_type,
+                        )
+
+            for dither_file in dither_files:
+                with datamodels.open(dither_file) as im:
+                    im = apply_subtraction(im,
+                                           delta,
+                                           fit_type=fit_type,
+                                           ref_ra=ref_ra,
+                                           ref_dec=ref_dec,
+                                           ref_wcs=optimal_wcs,
+                                           ref_shape=optimal_shape,
+                                           )
+                    im.save(dither_file)
+                del im
+
+        return True
+
     def calculate_delta(
             self,
             files,
+            fit_type="level",
             stacked_image=False,
             procs=None,
     ):
@@ -682,18 +1263,27 @@ class LevelMatchStep:
 
         Args:
             files (list): List of files to match
+            fit_type: Which type of fit to do. See ALLOWED_FIT_TYPES. Defaults to "level"
             stacked_image: Whether this is a stacked image or not.
                 Default to False
             procs (int, optional): Number of processes to run in
                 parallel. Defaults to None, which is series
         """
 
-        files = files
+        if fit_type == "level":
+            n_coeff = 1
+        elif fit_type == "level+slope":
+            n_coeff = 3
+        else:
+            raise ValueError(f"fit_type should be one of {ALLOWED_FIT_TYPES}")
 
-        deltas = np.zeros([len(files), len(files)])
-        weights = np.zeros_like(deltas)
-        rmses = np.zeros_like(deltas)
-        lin_sizes = np.ones_like(deltas)
+        deltas = np.zeros([len(files), len(files), n_coeff])
+        weights = np.zeros([len(files), len(files)])
+        rmses = np.zeros_like(weights)
+        lin_sizes = np.ones_like(weights)
+        valid_mat = np.ones_like(weights)
+        for i in range(len(files)):
+            valid_mat[i, i] = 0
 
         # Reproject all the HDUs. Start by building the optimal WCS
         if isinstance(files[0], list):
@@ -703,11 +1293,17 @@ class LevelMatchStep:
 
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
+
+            # Get optimal WCS
             optimal_wcs, optimal_shape = find_optimal_celestial_wcs(
                 files_flat,
                 hdu_in="SCI",
                 auto_rotate=True,
             )
+
+        # The reference pixels are the centre of the shape, but we also want this as RA/Dec
+        ref_y, ref_x = np.asarray(optimal_shape) // 2
+        ref_ra, ref_dec = get_ra_dec_values(optimal_wcs, ref_x, ref_y)
 
         if procs is None:
             # Use a serial method
@@ -726,6 +1322,7 @@ class LevelMatchStep:
                 )
 
             for i in range(len(files)):
+
                 for j in range(i + 1, len(files)):
                     plot_name = self.get_plot_name(
                         files[i],
@@ -735,19 +1332,26 @@ class LevelMatchStep:
                     n_pix, delta, rms, lin_size = self.get_level_match(
                         files1=file_reproj[i],
                         files2=file_reproj[j],
+                        fit_type=fit_type,
+                        ref_x=ref_x,
+                        ref_y=ref_y,
                         plot_name=plot_name,
                     )
 
-                    # These are symmetrical by design
-                    if n_pix == 0 or delta is None:
+                    # These are symmetrical by design, but anything where we don't have values is invalid
+                    if n_pix == 0 or delta is None or rms is None:
+                        valid_mat[i, j] = 0
+                        valid_mat[j, i] = 0
                         continue
 
-                    deltas[j, i] = delta
+                    for n in range(n_coeff):
+                        deltas[j, i, n] = delta[n]
+                        deltas[i, j, n] = -delta[n]
+
                     weights[j, i] = n_pix
                     rmses[j, i] = rms
                     lin_sizes[j, i] = lin_size
 
-                    deltas[i, j] = -delta
                     weights[i, j] = n_pix
                     rmses[i, j] = rms
                     lin_sizes[i, j] = lin_size
@@ -797,7 +1401,10 @@ class LevelMatchStep:
                 ij, delta, n_pix, rms, lin_size = self.parallel_delta_matrix(
                     ij=ij,
                     files=files,
+                    fit_type=fit_type,
                     file_reproj=file_reproj,
+                    ref_x=ref_x,
+                    ref_y=ref_y,
                 )
 
                 ijs.append(ij)
@@ -810,28 +1417,35 @@ class LevelMatchStep:
                 i = ij[0]
                 j = ij[1]
 
-                if n_pix_vals[idx] == 0 or delta_vals[idx] is None:
+                if n_pix_vals[idx] == 0 or delta_vals[idx] is None or rms_vals[idx] is None:
+                    valid_mat[i, j] = 0
+                    valid_mat[j, i] = 0
                     continue
 
-                deltas[j, i] = delta_vals[idx]
+                for n in range(n_coeff):
+                    deltas[j, i, n] = delta_vals[idx][n]
+                    deltas[i, j, n] = -delta_vals[idx][n]
+
                 weights[j, i] = n_pix_vals[idx]
                 rmses[j, i] = rms_vals[idx]
                 lin_sizes[j, i] = lin_size_vals[idx]
 
-                deltas[i, j] = -delta_vals[idx]
                 weights[i, j] = n_pix_vals[idx]
                 rmses[i, j] = rms_vals[idx]
                 lin_sizes[i, j] = lin_size_vals[idx]
 
             gc.collect()
 
-        return deltas, weights, rmses, lin_sizes
+        return deltas, weights, rmses, lin_sizes, valid_mat, optimal_wcs, optimal_shape, ref_ra, ref_dec
 
     def parallel_delta_matrix(
             self,
             ij,
             file_reproj,
             files,
+            fit_type="level",
+            ref_x=0,
+            ref_y=0,
     ):
         """Function to parallelise up getting delta matrix values
 
@@ -839,6 +1453,9 @@ class LevelMatchStep:
             ij: List of matrix (i, j) values
             file_reproj: Reprojected file
             files: Full list of files
+            fit_type: Which type of fit to do. See ALLOWED_FIT_TYPES. Defaults to "level"
+            ref_x: Reference x value to subtract to centre the fits. Defaults to 0
+            ref_y: Reference y value to subtract to centre the fits. Defaults to 0
         """
 
         i = ij[0]
@@ -855,6 +1472,9 @@ class LevelMatchStep:
             n_pix, delta, rms, lin_size = self.get_level_match(
                 files1=file_reproj[i],
                 files2=file_reproj[j],
+                fit_type=fit_type,
+                ref_x=ref_x,
+                ref_y=ref_y,
                 plot_name=plot_name,
             )
 
@@ -866,20 +1486,38 @@ class LevelMatchStep:
             self,
             files1,
             files2,
+            fit_type,
+            ref_x=0,
+            ref_y=0,
             plot_name=None,
             maxiters=10,
+            plane_fit_maxiters=20,
+            plane_fit_abs_tol=0,
+            plane_fit_rel_tol=1e-5,
     ):
         """Calculate relative difference between groups of files on the same pixel grid
 
         Args:
             files1: List of files to get difference from
             files2: List of files to get relative difference to
+            fit_type: Which type of fit to do. See ALLOWED_FIT_TYPES. Defaults to "level"
+            ref_x: Reference x-coord to perform fits relative to. Defaults to 0
+            ref_y: Reference y-coord to perform fits relative to. Defaults to 0
             plot_name: Output plot name. Defaults to None
             maxiters: Maximum iterations for the sigma-clipping. Defaults
                 to 10
+            plane_fit_maxiters: Maximum number of iterations for the plane fitting.
+                Defaults to 20
+            plane_fit_abs_tol: Absolute tolerance to define convergence in the
+                plane fit. Defaults to 0 (i.e. don't use absolute tolerances)
+            plane_fit_rel_tol: Relative tolerance to define convergence in
+                the plane fitting. Defaults to 1e-5
         """
 
         diffs = []
+        errs = []
+        iis = []
+        jjs = []
 
         if not isinstance(files1, list):
             files1 = [files1]
@@ -902,9 +1540,14 @@ class LevelMatchStep:
         for file_idx1, file1 in enumerate(files1):
             # Get out coordinates where data is valid, so we can do a linear
             # extent test
-            ii, jj = np.indices(file1.array.shape, dtype=float)
-            ii[np.where(np.isnan(file1.array))] = np.nan
-            jj[np.where(np.isnan(file1.array))] = np.nan
+            file1_data = copy.deepcopy(file1["data"])
+            file1_err = copy.deepcopy(file1["err"])
+
+            ii, jj = np.indices(file1_data.array.shape, dtype=float)
+            nan_idx = np.where(np.isnan(file1_data.array))
+
+            ii[nan_idx] = np.nan
+            jj[nan_idx] = np.nan
 
             # If we have something that's all NaNs
             # (e.g. lyot on MIRI subarray obs.), skip
@@ -915,19 +1558,30 @@ class LevelMatchStep:
             file1_jaxis = np.nanmax(jj) - np.nanmin(jj)
 
             for file_idx2, file2 in enumerate(files2):
-                if file2.overlaps(file1):
+
+                file2_data = copy.deepcopy(file2["data"])
+                file2_err = copy.deepcopy(file2["err"])
+
+                if file2_data.overlaps(file1_data):
+
                     # Get diffs, remove NaNs
-                    diff = file2 - file1
+                    diff = file2_data - file1_data
                     diff_arr = diff.array
                     diff_foot = diff.footprint
                     diff_arr[diff == 0] = np.nan
                     diff_arr[diff_foot == 0] = np.nan
 
+                    # Pull out error arrays, remove NaNs
+                    err = file1_err * file1_err + file2_err * file2_err
+                    err_arr = np.sqrt(err.array)
+                    err_arr[diff == 0] = np.nan
+                    err_arr[diff_foot == 0] = np.nan
+
                     # Get out coordinates where data is valid, so we can do a linear
                     # extent test
-                    ii, jj = np.indices(file2.array.shape, dtype=float)
-                    ii[np.where(np.isnan(file2.array))] = np.nan
-                    jj[np.where(np.isnan(file2.array))] = np.nan
+                    ii, jj = np.indices(file2_data.array.shape, dtype=float)
+                    ii[np.where(np.isnan(file2_data.array))] = np.nan
+                    jj[np.where(np.isnan(file2_data.array))] = np.nan
 
                     # If we have something that's all NaNs
                     # (e.g. lyot on MIRI subarray obs.), skip
@@ -944,6 +1598,7 @@ class LevelMatchStep:
                     # If the slices are all NaNs, then we can just move on
                     if np.all(np.isnan(ii)):
                         continue
+
                     diff_iaxis = np.nanmax(ii) - np.nanmin(ii)
                     diff_jaxis = np.nanmax(jj) - np.nanmin(jj)
 
@@ -956,10 +1611,22 @@ class LevelMatchStep:
                     ):
                         lin_size = 1
 
-                    diff = diff_arr[np.isfinite(diff_arr)].tolist()
+                    valid_idx = np.isfinite(diff_arr)
+
+                    # Get the coords, account for the differences in where the arrays start
+                    # IMPORTANT: Our indexing conventions are different to reproject, so i/j
+                    # gets swapped
+                    diff_ii = ii[valid_idx] + diff.jmin
+                    diff_jj = jj[valid_idx] + diff.imin
+
+                    diff = diff_arr[valid_idx].tolist()
+                    err = err_arr[valid_idx].tolist()
                     n_pix += len(diff)
 
                     diffs.extend(diff)
+                    errs.extend(err)
+                    iis.extend(diff_ii)
+                    jjs.extend(diff_jj)
 
                     if plot_name is not None:
                         if len(diff) > 0:
@@ -981,49 +1648,249 @@ class LevelMatchStep:
             plt.close()
 
         if n_pix > 0:
-            # Sigma-clip to remove outliers in the distribution
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                _, delta, rms = sigma_clipped_stats(diffs, maxiters=maxiters)
 
-            if plot_name is not None:
-                # Get histogram range
-                diffs_hist = None
+            if fit_type == "level":
+                # Just fit a DC offset. Sigma-clip to remove outliers in the distribution
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    _, delta, rms = sigma_clipped_stats(diffs, sigma=self.sigma, maxiters=maxiters)
+
+                if plot_name is not None:
+                    # Get histogram range
+                    diffs_hist = None
+
+                    if self.max_points is not None:
+                        if len(diffs) > self.max_points:
+                            diffs_hist = random.sample(diffs, self.max_points)
+                    if diffs_hist is None:
+                        diffs_hist = copy.deepcopy(diffs)
+
+                    hist_range = np.nanpercentile(diffs_hist, [1, 99])
+
+                    plt.figure(figsize=(5, 4))
+                    plt.hist(
+                        diffs_hist,
+                        histtype="step",
+                        bins=50,
+                        range=hist_range,
+                        color="gray",
+                    )
+                    plt.axvline(
+                        delta,
+                        c="k",
+                        ls="--",
+                    )
+
+                    plt.xlabel("Diff (MJy/sr)")
+                    plt.ylabel("$N$")
+
+                    plt.grid()
+
+                    plt.tight_layout()
+
+                    plt.savefig(f"{plot_name}_hist.pdf", bbox_inches="tight")
+                    plt.savefig(f"{plot_name}_hist.png", bbox_inches="tight")
+                    plt.close()
+
+                # For consistency with how we'll do things later, put this into a list
+                delta = [delta]
+
+            elif fit_type == "level+slope":
+
+                diffs = np.array(diffs)
+                errs = np.array(errs)
+
+                # For this, we do a slope fit in the x, y, rather than RA/Dec plane
+                # to avoid any potential spherical weirdness
+                iis = np.array(iis)
+                jjs = np.array(jjs)
+
+                jjs -= ref_x
+                iis -= ref_y
+
+                # Also remove a mean x/y, to avoid fitting spurious correlations
+                mean_j = np.nanmean(jjs)
+                mean_i = np.nanmean(iis)
+                jjs -= mean_j
+                iis -= mean_i
+
+                initial_offset = np.nanmedian(diffs)
+
+                # Get an initial guess which we'll normalise things by. This is just a flat plane
+                delta = np.array([0, 0, initial_offset], dtype=float)
+
+                # Set up an initial difference for comparison, with really big numbers
+                delta_diff = np.ones_like(delta) * 1e9
+
+                converged = False
+                n_iter = 0
+
+                while not converged and n_iter <= plane_fit_maxiters:
+
+                    # prev_delta = copy.deepcopy(delta)
+                    prev_delta_diff = copy.deepcopy(delta_diff)
+
+                    # Look at the current plane we have, and reject points that are
+                    # significantly different to it
+                    delta_plane = plane(jjs, iis, delta)
+                    rms = np.nanstd(diffs - delta_plane)
+
+                    fit_idx = np.where(np.abs(diffs - delta_plane) < self.sigma * rms)
+
+                    # Do a fit to the residuals, using only the points we care about
+                    points = np.vstack(
+                        (
+                            jjs[fit_idx],
+                            iis[fit_idx],
+                            diffs[fit_idx] - delta_plane[fit_idx],
+                        )
+                    ).T
+
+                    func = partial(plane_resid,
+                                   points=points,
+                                   err=errs[fit_idx],
+                                   )
+                    res = minimize(func,
+                                   delta,
+                                   method="Powell",
+                                   )
+
+                    delta_diff = copy.deepcopy(res.x)
+
+                    # Add this to our final delta
+                    delta += delta_diff
+
+                    # If the changes are very small, then just call this converged and jump out
+                    if np.all(np.isclose(delta_diff,
+                                         prev_delta_diff,
+                                         atol=plane_fit_abs_tol,
+                                         rtol=plane_fit_rel_tol,
+                                         )
+                              ):
+                        converged = True
+                        log.debug(f"Plane fitting converged after {n_iter} iterations")
+
+                    n_iter += 1
+
+                if not converged:
+                    log.debug(f"Plane fitting did not converge after {n_iter-1} iterations")
+
+                ii_min, ii_max = np.nanmin(iis), np.nanmax(iis)
+                jj_min, jj_max = np.nanmin(jjs), np.nanmax(jjs)
+
+                # Get residuals from the best plane
+                best_plane = plane(
+                    jjs,
+                    iis,
+                    delta,
+                )
+                resid = diffs - best_plane
+
+                # Get a measure of the RMS
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    _, _, rms = sigma_clipped_stats(resid,
+                                                    sigma=self.sigma,
+                                                    maxiters=maxiters,
+                                                    )
+
+                # Get histogram range for residuals
+                resid_hist = None
 
                 if self.max_points is not None:
-                    if len(diffs) > self.max_points:
-                        diffs_hist = random.sample(diffs, self.max_points)
-                if diffs_hist is None:
-                    diffs_hist = copy.deepcopy(diffs)
+                    if len(resid) > self.max_points:
+                        resid_hist = random.sample(list(resid), self.max_points)
+                if resid_hist is None:
+                    resid_hist = copy.deepcopy(resid)
 
-                hist_range = np.nanpercentile(diffs_hist, [1, 99])
+                # And also points to scatter
+                scatter_idx = None
 
-                plt.figure(figsize=(5, 4))
-                plt.hist(
-                    diffs_hist,
+                if self.max_points is not None:
+                    if len(resid) > self.max_points:
+                        scatter_idx = np.array(random.sample(range(len(resid)), self.max_points))
+                if scatter_idx is None:
+                    scatter_idx = slice(None)
+
+                hist_range = np.nanpercentile(resid, [1, 99])
+
+                # Get the plane to show the fit
+                xx, yy = np.meshgrid([jj_min, jj_max], [ii_min, ii_max])
+                z = delta[0] * xx + delta[1] * yy + delta[2]
+
+                # Make a plot that shows the plane fit through the points on the left, and the
+                # residuals on the right
+                fig = plt.figure(figsize=(8, 4))
+
+                ax_3d = fig.add_subplot(1, 2, 1, projection='3d')
+
+                ax_3d.set_proj_type('ortho')
+                ax_3d.view_init(elev=30, azim=45, roll=0)
+
+                ax_3d.scatter(
+                    jjs[scatter_idx],
+                    iis[scatter_idx],
+                    diffs[scatter_idx],
+                    c='k',
+                    marker='.',
+                    alpha=0.1,
+                    rasterized=True,
+                )
+                ax_3d.plot_surface(xx, yy, z, alpha=0.4, color='red')
+
+                ax_3d.set_xlim(jj_min, jj_max)
+                ax_3d.set_ylim(ii_min, ii_max)
+                ax_3d.ticklabel_format(useOffset=False)
+
+                if ref_x is not None:
+                    x_label = r"$\Delta x$"
+                else:
+                    x_label = r"$x$"
+
+                if ref_y is not None:
+                    y_label = r"$\Delta y$"
+                else:
+                    y_label = r"$y$"
+
+                ax_3d.set_xlabel(f"{x_label} (pix)")
+                ax_3d.set_ylabel(f"{y_label} (pix)")
+                ax_3d.set_zlabel("Diff (MJy/sr)")
+
+                ax_3d.xaxis.labelpad = 10
+                ax_3d.yaxis.labelpad = 10
+
+                ax_resid = fig.add_subplot(1, 2, 2)
+                ax_resid.hist(
+                    resid_hist,
                     histtype="step",
                     bins=50,
                     range=hist_range,
                     color="gray",
                 )
-                plt.axvline(
-                    delta,
-                    c="k",
-                    ls="--",
-                )
+                ax_resid.set_xlabel("Residual (MJy/sr)")
+                ax_resid.set_ylabel("$N$")
 
-                plt.xlabel("Diff (MJy/sr)")
-                plt.ylabel("$N$")
+                ax_resid.yaxis.set_label_position("right")
+                ax_resid.yaxis.tick_right()
+
+                ax_resid.grid()
 
                 plt.tight_layout()
 
-                plt.savefig(f"{plot_name}_hist.pdf", bbox_inches="tight")
-                plt.savefig(f"{plot_name}_hist.png", bbox_inches="tight")
+                plt.savefig(f"{plot_name}_plane_fit.pdf", bbox_inches="tight", dpi=300)
+                plt.savefig(f"{plot_name}_plane_fit.png", bbox_inches="tight", dpi=300)
                 plt.close()
+
+                # Translate this back to the central coordinate, since we subtracted that off earlier
+                z_offset = delta[0] * mean_j + delta[1] * mean_i
+                delta[-1] -= z_offset
+
+            else:
+                raise ValueError(f"fit_type should be one of {ALLOWED_FIT_TYPES}")
 
         else:
             delta = None
-            rms = 0
+            rms = None
 
         gc.collect()
 
@@ -1035,17 +1902,39 @@ class LevelMatchStep:
             npix_mat,
             rms_mat,
             lin_size_mat,
+            valid_mat,
+            fit_type="level",
+            n_draws=25,
+            n_iter=10000,
+            convergence_abs_tol=0,
+            convergence_rel_tol=1e-5,
+            ref_idx=None,
     ):
         """Get optimum deltas from a delta/weight matrix.
 
         Taken from the JWST skymatch step, with some edits to remove potentially bad fits due
-        to small areal overlaps, or noisy diffs, and various weighting schemes
+        to small areal overlaps, or noisy diffs, and various weighting schemes.
+
+        If we're fitting a plane, delta_mat will be an NxNx3 matrix, and we'll minimize over
+        each of the last axes separately
 
         Args:
-            delta_mat (np.ndarray): Matrix of delta values
+            delta_mat (np.ndarray): Matrix of delta values. These may be [a, b, c] coefficients
+                if we're fitting a plane
             npix_mat (np.ndarray): Matrix of number of pixel values for calculating delta
             rms_mat (np.ndarray): Matrix of RMS values
             lin_size_mat (np.ndarray): 1/0 array for whether overlaps pass minimum linear extent
+            valid_mat (np.ndarray): 1/0 array for whether overlaps are valid
+            fit_type: Which type of fit to do. See ALLOWED_FIT_TYPES. Defaults to "level"
+            n_draws: When using the iterative method, we need to sample from the fitted plane. This
+                controls how many draws we do. Defaults to 25
+            n_iter: Maximum number of iterations before breaking out of the fitting routine. Defaults
+                to 10,000
+            convergence_abs_tol: Absolute tolerance to define convergence. Defaults to 0 (i.e. don't use
+                absolute tolerances)
+            convergence_rel_tol: Relative tolerance to define convergence. Defaults to 1e-5
+            ref_idx: Index to define the zero level for all the level matching. Defaults to None, which
+                will use the average correction
         """
 
         delta_mat = copy.deepcopy(delta_mat)
@@ -1055,39 +1944,30 @@ class LevelMatchStep:
 
         ns = delta_mat.shape[0]
 
-        # Remove things with weights less than min_area_percent of the average weight
-        avg_npix_val = np.nanmean(npix_mat[npix_mat != 0])
-        small_area_idx = np.where(
-            np.logical_and(
-                npix_mat < self.min_area_percent * avg_npix_val, delta_mat != 0
-            )
-        )
-        delta_mat[small_area_idx] = 0
-        npix_mat[small_area_idx] = 0
-        rms_mat[small_area_idx] = 0
+        # Matrix for fits that we'll actually use
+        use_mat = copy.deepcopy(valid_mat)
+
+        # Remove things with weights less than min_area_percent of the average weight. Use all overlaps here
+        avg_npix_val = np.nanmean(npix_mat[valid_mat == 1])
+        small_area_idx = npix_mat < self.min_area_percent * avg_npix_val
+
+        use_mat[small_area_idx] = 0
 
         # Remove things that haven't passed the small area test
-        delta_mat[lin_size_mat == 0] = 0
-        npix_mat[lin_size_mat == 0] = 0
-        rms_mat[lin_size_mat == 0] = 0
+        use_mat[lin_size_mat == 0] = 0
 
-        # Remove fits with RMS values twice that of the mean
-        avg_rms_val = np.nanmean(rms_mat[npix_mat != 0])
-        sig_rms_val = np.nanstd(rms_mat[npix_mat != 0])
+        # Remove fits with RMS values some sigma above the mean. Use only good overlaps here
+        avg_rms_val = np.nanmean(rms_mat[np.logical_and(valid_mat == 1, use_mat == 1)])
+        sig_rms_val = np.nanstd(rms_mat[np.logical_and(valid_mat == 1, use_mat == 1)])
+
         rms_idx = np.where(rms_mat > avg_rms_val + self.rms_sig_limit * sig_rms_val)
-        delta_mat[rms_idx] = 0
-        npix_mat[rms_idx] = 0
-        rms_mat[rms_idx] = 0
 
-        # Make sure we've got rid of everything we need to
-        delta_mat[npix_mat == 0] = 0
-        delta_mat[rms_mat == 0] = 0
+        use_mat[rms_idx] = 0
 
         # Create weight matrix
         if self.weight_method == "equal":
             # Weight evenly
             weight = np.ones_like(delta_mat)
-            weight[delta_mat == 0] = 0
         elif self.weight_method == "npix":
             # Weight by straight number of pixels
             weight = 0.5 * (npix_mat + npix_mat.T)
@@ -1104,12 +1984,12 @@ class LevelMatchStep:
         neq = 0
         for i in range(ns):
             for j in range(i + 1, ns):
-                if delta_mat[i, j] != 0 and npix_mat[i, j] > 0 and weight[i, j] > 0:
+                if valid_mat[i, j] == 1 and use_mat[i, j] == 1:
                     neq += 1
 
         # Create arrays for coefficients and free terms
         k = np.zeros((neq, ns), dtype=float)
-        f = np.zeros(neq, dtype=float)
+        f = np.zeros([neq, delta_mat.shape[-1]], dtype=float)
         invalid = ns * [True]
 
         # Process intersections between the rest of the images
@@ -1117,11 +1997,13 @@ class LevelMatchStep:
         for i in range(0, ns):
             for j in range(i + 1, ns):
                 # Only pull out valid intersections
-                if delta_mat[i, j] != 0 and weight[i, j] > 0 and npix_mat[i, j] > 0:
+                if valid_mat[i, j] == 1 and use_mat[i, j] == 1:
                     k[ieq, i] = weight[i, j]
                     k[ieq, j] = -weight[i, j]
 
-                    f[ieq] = weight[i, j] * delta_mat[i, j]
+                    for coeff in range(delta_mat.shape[-1]):
+                        f[ieq, coeff] = weight[i, j] * delta_mat[i, j, coeff]
+
                     invalid[i] = False
                     invalid[j] = False
                     ieq += 1
@@ -1139,10 +2021,218 @@ class LevelMatchStep:
             logging.warning("Sky matching (delta) values will be computed only for")
             logging.warning("a subset (or more independent subsets) of input images.")
 
-        inv_k = np.linalg.pinv(k, rcond=1.0e-12)
+        # Uses the iterative montage method to find best fits
 
-        deltas = np.dot(inv_k, f)
-        deltas[np.asarray(invalid, dtype=bool)] = 0
+        deltas = np.zeros([ns, delta_mat.shape[-1]])
+        delta_mat_corr = copy.deepcopy(delta_mat)
+
+        converged = False
+        level_converged = False
+
+        # Set a max number of iterations to just run level matching. This is
+        # either 2500 or half the number of iterations if the iteration
+        # number is relatively small
+        if n_iter < 5000:
+            n_level = n_iter // 2
+        else:
+            n_level = 2500
+
+        iteration = 0
+        level_iteration = 0
+
+        # Iterate until convergence or some maximum number of iterations
+        while not converged and iteration < n_iter:
+
+            # We'll start off just trying to optimize the DC offsets
+            if fit_type in ["level+slope"] and not level_converged:
+                curr_fit_type = "level"
+            else:
+                curr_fit_type = copy.deepcopy(fit_type)
+
+            # Pull useful things out to dictionaries since we'll update
+            # everything in bulk at the end
+            delta_arr = {}
+            best_fits = {}
+
+            delta_mat_corr_prev = copy.deepcopy(delta_mat_corr)
+
+            for i in range(ns):
+                if invalid[i]:
+                    continue
+
+                delta_arr[i] = {}
+
+                # Loop over and pull out any valid overlaps
+                for j in range(ns):
+                    if i == j:
+                        continue
+
+                    if invalid[j]:
+                        continue
+
+                    # Only take fits we actually want to use
+                    if valid_mat[i, j] == 1 and use_mat[i, j] == 1:
+                        delta_arr[i][j] = copy.deepcopy(delta_mat_corr[i, j, :])
+
+                # For each delta value, we want to sample randomly in the (x, y) plane
+                weight_vals = []
+                x_vals = []
+                y_vals = []
+                z_vals = []
+
+                # For a starting guess, take the average of the various coefficients
+                delta_arr_stack = np.array([list(delta_arr[i][d]) for d in delta_arr[i]])
+                p0 = np.nanmean(delta_arr_stack, axis=0)
+
+                # Sample some points in the plane
+                x = np.random.normal(loc=0, scale=1, size=n_draws)
+                y = np.random.normal(loc=0, scale=1, size=n_draws)
+
+                for j in delta_arr[i]:
+
+                    if invalid[j]:
+                        continue
+
+                    # This is where we're fitting, so only use the values that we've defined as good
+                    if valid_mat[i, j] == 0 or use_mat[i, j] == 0:
+                        continue
+
+                    arr_val = copy.deepcopy(delta_arr[i][j])
+
+                    if curr_fit_type == "level":
+                        coeffs = np.array([0, 0, arr_val[-1]])
+                    elif curr_fit_type == "level+slope":
+                        coeffs = copy.deepcopy(arr_val)
+                    else:
+                        raise ValueError(f"Unknown fit type: {curr_fit_type}")
+
+                    z = coeffs[0] * x + coeffs[1] * y + coeffs[2]
+
+                    weight_vals.extend([weight[i, j]] * n_draws)
+                    x_vals.extend(list(x))
+                    y_vals.extend(list(y))
+                    z_vals.extend(list(z))
+
+                x_vals = np.array(x_vals)
+                y_vals = np.array(y_vals)
+                z_vals = np.array(z_vals)
+                weight_vals = np.array(weight_vals)
+
+                if curr_fit_type == "level":
+
+                    # Just get an average of the offsets
+                    best_fit_vals = np.average(z_vals,
+                                               weights=np.sqrt(weight_vals),
+                                               keepdims=True,
+                                               )
+
+                elif curr_fit_type == "level+slope":
+
+                    # Use scipy minimize to get a best fit plane
+                    points = np.vstack((x_vals, y_vals, z_vals)).T
+
+                    # Here, the error is the inverse of the weights
+                    func = partial(plane_resid,
+                                   points=points,
+                                   err=np.sqrt(weight_vals) ** -1,
+                                   )
+                    res = minimize(func,
+                                   p0,
+                                   method="Powell",
+                                   )
+
+                    # Pull out best fit, calculate the stats and update
+                    # which points we're fitting
+                    best_fit_vals = copy.deepcopy(res.x)
+
+                else:
+                    raise ValueError(f"Unknown fit type: {curr_fit_type}")
+
+                if curr_fit_type == "level":
+                    best_fit = np.zeros(delta_mat.shape[-1])
+                    best_fit[-1] = best_fit_vals[-1]
+                elif curr_fit_type == "level+slope":
+                    best_fit = copy.deepcopy(best_fit_vals)
+                else:
+                    raise ValueError(f"Fit type {curr_fit_type} is not known.")
+
+                # Factor of 2 to keep things symmetrical
+                best_fit /= 2
+
+                best_fits[i] = copy.deepcopy(best_fit)
+
+            for i in range(ns):
+                if i not in best_fits:
+                    continue
+
+                # Add on the best fits
+                deltas[i, :] += best_fits[i]
+
+            # Edit the corrections, doing this for all valid fits
+            for i in range(ns):
+
+                if invalid[i]:
+                    continue
+
+                if i not in best_fits:
+                    continue
+
+                for j in range(ns):
+
+                    if i == j:
+                        continue
+
+                    if invalid[j]:
+                        continue
+
+                    if valid_mat[i, j] == 0:
+                        continue
+
+                    # Apply the corrections within the matrix
+                    delta_mat_corr[i, j, :] -= best_fits[i]
+                    delta_mat_corr[i, j, :] += best_fits[j]
+
+            # Check for convergence. If the maximum difference hasn't
+            # changed within the tolerance, jump out and call it a day
+            has_converged = np.all(np.isclose(delta_mat_corr,
+                                              delta_mat_corr_prev,
+                                              atol=convergence_abs_tol,
+                                              rtol=convergence_rel_tol,
+                                              )
+                                   )
+
+            # if convergence_param < convergence_tol:
+            if has_converged:
+
+                if curr_fit_type != fit_type:
+                    level_converged = True
+                else:
+                    converged = True
+                log.info(f"Level matching converged after {iteration} iterations")
+
+            if level_iteration >= n_level and not level_converged:
+                log.info(f"Level matching has not converged after {iteration} iterations")
+                level_converged = True
+
+            # Update convergences
+            if not level_converged:
+                level_iteration += 1
+            if not converged:
+                iteration += 1
+
+        # If we don't have a selected reference index, take the average correction
+        if ref_idx is None:
+            offset_delta = np.nanmean(deltas, axis=0)
+        else:
+            offset_delta = copy.deepcopy(deltas[ref_idx, :])
+
+        # Set the reference image correction to 0, adjust all other
+        # corrections relative to that
+        for i in range(deltas.shape[0]):
+            deltas[i, :] -= offset_delta
+
+        # Set any invalid deltas to 0
+        deltas[np.asarray(invalid, dtype=bool), :] = 0
 
         return deltas
 
@@ -1164,25 +2254,46 @@ class LevelMatchStep:
 
         if isinstance(file, list):
             file_reproj = [
-                reproject_image(
+                {"data": reproject_image(
                     i,
                     optimal_wcs=optimal_wcs,
                     optimal_shape=optimal_shape,
                     do_sigma_clip=self.do_sigma_clip,
                     stacked_image=stacked_image,
                     reproject_func=self.reproject_func,
-                )
+                ),
+                    "err": reproject_image(
+                        i,
+                        optimal_wcs=optimal_wcs,
+                        optimal_shape=optimal_shape,
+                        hdu_type="err",
+                        do_sigma_clip=self.do_sigma_clip,
+                        stacked_image=stacked_image,
+                        reproject_func=self.reproject_func,
+                    ),
+                }
                 for i in file
             ]
         else:
-            file_reproj = reproject_image(
-                file,
-                optimal_wcs=optimal_wcs,
-                optimal_shape=optimal_shape,
-                do_sigma_clip=self.do_sigma_clip,
-                stacked_image=stacked_image,
-                reproject_func=self.reproject_func,
-            )
+            file_reproj = {
+                "data": reproject_image(
+                    file,
+                    optimal_wcs=optimal_wcs,
+                    optimal_shape=optimal_shape,
+                    do_sigma_clip=self.do_sigma_clip,
+                    stacked_image=stacked_image,
+                    reproject_func=self.reproject_func,
+                ),
+                "err": reproject_image(
+                    file,
+                    optimal_wcs=optimal_wcs,
+                    optimal_shape=optimal_shape,
+                    hdu_type="err",
+                    do_sigma_clip=self.do_sigma_clip,
+                    stacked_image=stacked_image,
+                    reproject_func=self.reproject_func,
+                ),
+            }
 
         return file_reproj
 

--- a/pjpipe/lv1/lv1_step.py
+++ b/pjpipe/lv1/lv1_step.py
@@ -6,6 +6,7 @@ import multiprocessing as mp
 import os
 import shutil
 from functools import partial
+import cv2 as cv
 
 import numpy as np
 from jwst.pipeline import calwebb_detector1
@@ -16,6 +17,9 @@ from ..utils import attribute_setter, save_file
 
 log = logging.getLogger("stpipe")
 log.addHandler(logging.NullHandler())
+
+# Set OpenCV number of threads to 1 to avoid MP issues on newer Macbooks
+cv.setNumThreads(1)
 
 
 class Lv1Step:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ name = "pjpipe"
 version = "1.1.0"
 description = "JWST Pipeline Wrapper for Nearby Galaxies"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {file = "LICENSE"}
 
 authors = [
@@ -23,9 +23,9 @@ classifiers = [
   # License
   "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
 
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 
 dependencies = [
@@ -33,29 +33,33 @@ dependencies = [
     "astroquery>=0.4.6",
     "cmocean>=3.1.3",
     "crds>=11.17.16",
-    "gwcs>=0.20.0",
+    "gwcs>=0.21.0",
     "image-registration>=0.2.8",
-    "jwst>=1.13.4",
+    "jwst>=1.14.0",
     "lmfit>=1.2.2",
     "matplotlib>=3.8.2",
-    "numpy>=1.26.4",
+    "numpy>=1.26.4,<2",
     "photutils>=1.10.0",
     "pypdf>=4.0.1",
     "pytest>=8.0.0",
-    "reproject>=0.13.0",
+    "reproject>=0.13.1",
     "requests>=2.31.0",
     "scikit-image>=0.22.0",
     "scipy>=1.12.0",
     "shapely>=2.0.2",
     "setuptools>=68.2.2",
-    "stdatamodels>=1.9.1",
+    "stdatamodels>=1.10.1",
     "stwcs>=1.7.2",
     "spacepylot@git+https://github.com/ejwatkins-astro/spacepylot.git",
     "threadpoolctl>=3.2.0",
     "tomli>=2.0.1",
     "tqdm>=4.66.1",
-    "tweakwcs==0.8.5",
+    "tweakwcs>=0.8.7",
     "webbpsf>=1.2.1",
+]
+
+[project.optional-dependencies]
+docs = [
     "sphinx-automodapi>=0.16.0",
     "sphinx-rtd-theme>=2.0.0",
 ]


### PR DESCRIPTION
This PR hugely extends the level_match capabilities to also allow for simple 2D planes as well as just a constant offset. This seems to be necessary in some cases, for reasons currently unclear.

The type of fitting can be specified at each stage via the new parameters:
- fit_type_dithers = "level"
- fit_type_recombine_lyot = "level+slope"
- fit_type_mosaic_tiles = "level+slope"
where the options are "level" (constant offset), and "level+slope" (plane)

When matching mosaic tiles, we need to define a reference image which we assume to be completely flat and edit other corrections relative to that. We either use the tile taken closest in time to the backgrounds (if they exist), or the one with maximal overlap between the tileset. As such, the lv2 step has been expanded slightly to include information on when the nearest background to the science observation was taken to make that easier

For now, this is a draft while we run through testing. Obvious test cases are NGC1792 and NGC253 where the level matching currently isn't great, but there may be others lurking