### PR TITLE
Fix warning for multi_tile_destripe_step.py with many input tile rotations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 1.1.1 (Unreleased)
 ==================
 
+- Removed raised warning in ``multi_tile_destripe_step`` when input images have a variety of
+  rotations
 - Added ``combine_nircam_short`` option in ``level_match_step``, which will match levels
   between the four NIRCam short imaging chips before doing matching between mosaic tiles
 - ``lv2_step`` will now propagate through individual exposure offset times from backgrounds,

--- a/pjpipe/multi_tile_destripe/multi_tile_destripe_step.py
+++ b/pjpipe/multi_tile_destripe/multi_tile_destripe_step.py
@@ -601,7 +601,6 @@ class MultiTileDestripeStep:
 
             # First case, we have a weird mix of rotations. In which case direction should be None
             if not np.all(internal_diff < 10):
-                raise ValueError("Input images have a variety of rotations. Have not encountered this before")
                 direction = None
                 log.info("Input images have a variety of rotations. Defaulting to smoothing over both axes")
 


### PR DESCRIPTION
This PR removes the warning when tiles have a variety of input rotations. This was here as a test case, and now @tonyweinbeck has found this in the M51 Treasury. All seems to be working fine