### PR TITLE
Degroup NIRCam modules enhancements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 1.2.1 (Unreleased)
 ==================
 
+- Fix crash in ``multi_tile_destripe_step`` for heavily masked data when doing smoothing
+- Fix crash in ``astrometric_align_step`` with new gwcs updates
+- Fix crash in ``lv3`` step when degrouping NIRCam modules
+- Allow for degrouping of NIRCam modules in ``get_wcs_adjust_step`` and ``apply_wcs_adjust_step``
 - Fix for crash if trying to anchor without first aligning
 - Fix for crash if trying to PSF match without some combination of anchoring, aligning
 - Change how the level 3 step handles models for newer JWST versions

--- a/pjpipe/astrometric_align/astrometric_align_step.py
+++ b/pjpipe/astrometric_align/astrometric_align_step.py
@@ -9,6 +9,12 @@ from functools import partial
 
 from astropy.io import fits
 import gwcs
+
+try:
+    from gwcs.utils import make_fitswcs_transform
+except ImportError:
+    from gwcs.wcs.utils import make_fitswcs_transform
+
 import numpy as np
 from astropy.table import QTable, Table
 from astropy.wcs import WCS
@@ -66,7 +72,7 @@ def transform_wcs_gwcs(wcs):
     """
 
     hdr = wcs.to_header()
-    tform = gwcs.wcs.utils.make_fitswcs_transform(hdr)
+    tform = make_fitswcs_transform(hdr)
     new_gwcs = gwcs.WCS(forward_transform=tform, output_frame="world")
 
     return hdr, new_gwcs

--- a/pjpipe/utils/__init__.py
+++ b/pjpipe/utils/__init__.py
@@ -19,6 +19,7 @@ from .utils import (
     level_data,
     save_file,
     make_stacked_image,
+    band_exts,
 )
 
 __all__ = [
@@ -42,4 +43,5 @@ __all__ = [
     "level_data",
     "save_file",
     "make_stacked_image",
+    "band_exts",
 ]


### PR DESCRIPTION
- Allow degrouping NIRCam modules for ``get_wcs_adjust`` and ``apply_wcs_adjust``
- Fix crash in lv3
- Fix crash in ``astrometric_align_step`` with new gwcs updates
- Fix crash in ``multi_tile_destripe_step`` for completely masked data when doing smoothing
