### PR TITLE
Strip whitespace, lowercase bkg association

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 1.2.1 (Unreleased)
 ==================
 
+- For background association, strip whitespace and lowercase for more robust matching
 - Imports update - now supports numpy>2.0!
 - Keep track of expected stripe direction in ``multi_tile_destripe_step``
 - Trim off reference pixels for median filter in ``single_tile_destripe_step``

--- a/pjpipe/utils/utils.py
+++ b/pjpipe/utils/utils.py
@@ -565,7 +565,7 @@ def parse_fits_to_table(
         # If the backgrounds are labelled differently in the target name
         elif check_type == "check_in_name":
             with datamodels.open(file) as im:
-                if background_name in im.meta.target.proposer_name.lower():
+                if background_name.strip().lower() in im.meta.target.proposer_name.strip().lower():
                     f_type = "bgr"
 
         # If we want to use some specific files within the science as observations


### PR DESCRIPTION
- For background association, strip whitespace and lowercase for more robust matching
