### PR TITLE
Fix crash for background observations in ``get_short_band_name``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 1.2.1 (Unreleased)
 ==================
 
+- Fix crash for background observations in ``get_short_band_name``
 - For background association, strip whitespace and lowercase for more robust matching
 - Imports update - now supports numpy>2.0!
 - Keep track of expected stripe direction in ``multi_tile_destripe_step``

--- a/pjpipe/utils/utils.py
+++ b/pjpipe/utils/utils.py
@@ -241,6 +241,7 @@ def get_band_ext(band):
 
     return band_ext
 
+
 def get_short_band_name(band):
     """Get a stripped down short name for a band"""
 
@@ -248,7 +249,7 @@ def get_short_band_name(band):
 
     # Strip background
     if "_bgr" in band_short:
-        band_short = band_short.replace("_bgr")
+        band_short = band_short.replace("_bgr", "")
 
     # Strip instrument names
     if "_niriss" in band_short:


### PR DESCRIPTION
Fixes #90

- Fix crash for background observations in ``get_short_band_name``
