### PR TITLE
directory creation fix in psf_matching step and pipeline.py

### DIFF
--- a/pjpipe/pipeline.py
+++ b/pjpipe/pipeline.py
@@ -433,11 +433,17 @@ class PJPipeline:
                             band_dir,
                             out_band_dir,
                         )
-
+                        log.info(f"out_dir: {out_dir}")
                         if not os.path.exists(in_dir):
+                            log.info(f"Making in_dir: {in_dir}")
                             os.makedirs(in_dir)
+                        else:
+                            log.info(f"in_dir exists: {in_dir}")
                         if not os.path.exists(out_dir):
+                            log.info(f"Making out_dir: {out_dir}")
                             os.makedirs(out_dir)
+                        else:
+                            log.info(f"out_dir exists: {out_dir}")
 
                         # Move raw observations
                         if not progress_dict[target][band_full]["data_moved"]:

--- a/pjpipe/psf_matching/psf_matching_step.py
+++ b/pjpipe/psf_matching/psf_matching_step.py
@@ -90,7 +90,9 @@ class PSFMatchingStep:
             )
         )
         files.sort()
-
+        # Make the output directory if it doesn't exist
+        if not os.path.exists(self.out_dir):    
+            os.makedirs(self.out_dir)
         # If we don't have anything, warn but succeed
         if len(files) == 0:
             log.warning("No files found, will skip this step")


### PR DESCRIPTION
psf_matching_step was missing line where the psf_matching directory was created (affected cases where PSF matching was not done for specific bands or if it was skipped because kernels didn't exist)