### PR TITLE
catch errors in anchor intensity range calcs

### DIFF
--- a/pjpipe/anchoring/intensity_ranges.py
+++ b/pjpipe/anchoring/intensity_ranges.py
@@ -84,28 +84,50 @@ def get_galaxy_specs(fname_table, galaxy='ngc0628'):
         Position angle in degrees
     incl : float
         Inclination angle in degrees
-    dist : float
-        Distance in Mpc
     reff : float
         Effective radius in arcsec
     """
     import pandas as pd
     
-    # Read the merged table
-    df = pd.read_csv(fname_table, comment='#')
+    # Read the merged table (raise error if something went wrong)
+    try:
+        df = pd.read_csv(fname_table, comment='#')
+    except Exception as e:
+        log.error(f'Error reading galaxy table {fname_table}: {e}')
+        raise e
     
     # Convert galaxy name to lowercase for case-insensitive matching
     galaxy = galaxy.lower()
+
+    # Check that the table has the required columns, and that the type of data in 
+    # each column is correct (float for all except name)
+    required_columns = ['name', 'ra', 'dec', 'posang', 'inclination', 'size_reff']
+    for column in required_columns:
+        if column not in df.columns:
+            log.error(f'Column {column} not found in table {fname_table}')
+            raise ValueError(f'Column {column} not found in table {fname_table}')
+        if column == 'name' and not isinstance(df[column].iloc[0], str):
+            log.error(f'Column {column} has incorrect type in table {fname_table} (expected string)')
+            raise ValueError(f'Column {column} has incorrect type in table {fname_table} (expected string)')
+        if column != 'name' and not isinstance(df[column].iloc[0], (float)):
+            log.error(f'Column {column} has incorrect type in table {fname_table} (expected float)')
+            raise ValueError(f'Column {column} has incorrect type in table {fname_table} (expected float)')
+
+    # Make sure galaxy names in table are lowercase for case-insensitive matching
+    df['name'] = df['name'].str.lower()
+
     row = df[df['name'] == galaxy].iloc[0]
-    
+    if len(row) == 0:
+        log.error(f'Galaxy {galaxy} not found in table {fname_table}')
+        raise ValueError(f'Galaxy {galaxy} not found in table {fname_table}')
+
     ra = row['ra']
     dec = row['dec']
     posang = row['posang']
     incl = row['inclination']
-    dist = row['distance_mpc']
     reff = row['size_reff']
-    
-    return ra, dec, posang, incl, dist, reff
+
+    return ra, dec, posang, incl, reff
 
 
 
@@ -134,49 +156,56 @@ def get_intensity_range(fname_image, fname_table, galaxy = 'ngc0628', reff_facto
         - xmax: maximum intensity value (at percentile_range[1])
         These values are used for binning in the anchoring step.
     """
-    # Input image is a JWST image (SCI extension)
-    # Load the image
-    with fits.open(fname_image) as hdul:
-        # Get the SCI extension
-        try:
-            sci = hdul['SCI']
-        except KeyError:
-            sci = hdul[0]
-        image = sci.data
-        header = sci.header
-        w = WCS(header)
-        shape = image.shape
+    try:
+        # Input image is a JWST image (SCI extension)
+        # Load the image
+        with fits.open(fname_image) as hdul:
+            # Get the SCI extension
+            try:
+                sci = hdul['SCI']
+            except KeyError:
+                sci = hdul[0]
+            image = sci.data
+            header = sci.header
+            w = WCS(header)
+            shape = image.shape
 
-    ra_deg, dec_deg, posang_deg, incl_deg, dist, reff_arcsec = get_galaxy_specs(fname_table, galaxy)
-    radius_deg, projang_deg = get_deprojected_radii(ra_deg, dec_deg, incl_deg, posang_deg, w, shape)
-    radius_arcsec = radius_deg * 60 * 60
+        ra_deg, dec_deg, posang_deg, incl_deg, reff_arcsec = get_galaxy_specs(fname_table, galaxy)
+        radius_deg, projang_deg = get_deprojected_radii(ra_deg, dec_deg, incl_deg, posang_deg, w, shape)
+        radius_arcsec = radius_deg * 60 * 60
 
-    # Get the intensity range within reff_factor * r_e of the center
-    mask = (radius_arcsec <= reff_factor * reff_arcsec)
-    mask = mask & (image != 0) & np.isfinite(image)
-    
-    # Ensure we have enough valid pixels
-    n_valid = np.sum(mask)
-
-
-    # Get intensity range
-    intensity_range = np.nanpercentile(image[mask], percentile_range)
-    xmin, xmax = intensity_range
-
-    # Log results
-    log.info(f'Intensity range report for {galaxy}:')
-    log.info(f'  Intensity range: [{xmin:.3f}, {xmax:.3f}] from {n_valid} pixels')
-    log.info(f'  Percentile range: {percentile_range}')
-    log.info(f'  Reff factor: {reff_factor} × {reff_arcsec:.1f}" = {reff_factor * reff_arcsec:.1f}"')
-    log.info(f'  Image shape: {image.shape}')
-    
-    # Final validation
-    if xmin >= xmax:
-        log.error(f'Invalid intensity range: {xmin} >= {xmax}. Using defaults.')
-        return 0.25, 2.0
-    
-    if not (np.isfinite(xmin) and np.isfinite(xmax)):
-        log.error(f'Non-finite intensity range: [{xmin}, {xmax}]. Using defaults.')
-        return 0.25, 2.0
+        # Get the intensity range within reff_factor * r_e of the center
+        mask = (radius_arcsec <= reff_factor * reff_arcsec)
+        mask = mask & (image != 0) & np.isfinite(image)
         
-    return xmin, xmax
+        # Ensure we have enough valid pixels
+        n_valid = np.sum(mask)
+
+
+        # Get intensity range
+        intensity_range = np.nanpercentile(image[mask], percentile_range)
+        xmin, xmax = intensity_range
+
+        # Log results
+        log.info(f'Intensity range report for {galaxy}:')
+        log.info(f'  Intensity range: [{xmin:.3f}, {xmax:.3f}] from {n_valid} pixels')
+        log.info(f'  Percentile range: {percentile_range}')
+        log.info(f'  Reff factor: {reff_factor} × {reff_arcsec:.1f}" = {reff_factor * reff_arcsec:.1f}"')
+        log.info(f'  Image shape: {image.shape}')
+        
+        # Final validation
+        if xmin >= xmax:
+            log.error(f'Invalid intensity range: {xmin} >= {xmax}. Using defaults.')
+            return 0.25, 2.0
+        
+        if not (np.isfinite(xmin) and np.isfinite(xmax)):
+            log.error(f'Non-finite intensity range: [{xmin}, {xmax}]. Using defaults.')
+            return 0.25, 2.0
+            
+        return xmin, xmax
+    
+    # Could put error catching specifically at get_galaxy_specs, but this will catch any other errors
+    # too so might as well catch them here
+    except Exception as e:
+        log.error(f'Error calculating intensity range for {galaxy}: {e}. Using defaults.')
+        return 0.25, 2.0


### PR DESCRIPTION
A CSV table of galaxy properties (name, RA, Dec, position angle, inclination, effective radius) is required for anchoring intensity range calculation to work. Code checks for errors in the format of the table, and revers to default intensity ranges if it is formatted incorrectly or if a galaxy is not in the table.