### PR TITLE
store flux level match coefficients in FITS headers

### DIFF
--- a/pjpipe/level_match/level_match_step.py
+++ b/pjpipe/level_match/level_match_step.py
@@ -148,6 +148,17 @@ def apply_subtraction(im,
 
     im.data[zero_idx] = 0
 
+    # Save level match coefficients to FITS header
+    if im.extra_fits.PRIMARY is None:
+        im.extra_fits.PRIMARY = []
+    
+    if fit_type == "level":
+        im.extra_fits.PRIMARY.append(('LVLMATCH', delta[0], 'Level match DC offset (MJy/sr)'))
+    elif fit_type == "level+slope":
+        im.extra_fits.PRIMARY.append(('LVLM_A', delta[0], 'Level match x-slope coeff'))
+        im.extra_fits.PRIMARY.append(('LVLM_B', delta[1], 'Level match y-slope coeff'))
+        im.extra_fits.PRIMARY.append(('LVLM_C', delta[2], 'Level match DC offset (MJy/sr)'))
+
     return im
 
 


### PR DESCRIPTION
Saving the calculated DC flux offsets that get subtracted from the data during pjpipe's `LevelMatchStep`. This is saved in Level 2 FITS headers.
- For DC level, it's stored as `LVLMATCH`.
- If fitting a plane, coefficients are stored as `LVLM_A` (x-slope)
`LVLM_B` (y-slope)
and `LVLM_C` (DC level).