### PR TITLE
Fix occasional all-NaN issue in ``single_tile_destripe``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,7 @@
 1.3.1 (Unreleased)
 ==================
 
+- Fix occasional all-NaN issue in ``single_tile_destripe``
 - Fix backgrounds being wrongly moved in ``lv1_step``
 - Moved ``astrometric_align`` to a combined step, to avoid list ordering issues
 - Updated dependencies, added specific pins, dependabot, and CODEOWNERS

--- a/pjpipe/single_tile_destripe/single_tile_destripe_step.py
+++ b/pjpipe/single_tile_destripe/single_tile_destripe_step.py
@@ -1645,7 +1645,10 @@ class SingleTileDestripeStep:
             sigclip_iters=self.max_iters,
         )
 
-        mask = mask_pos | mask_neg | dq_mask
+        # And any non-finite values that might have crept in
+        non_finite_idx = ~np.isfinite(data)
+
+        mask = mask_pos | mask_neg | dq_mask | non_finite_idx
 
         return data, mask
 


### PR DESCRIPTION
Sometimes, the Butterworth filter seems to add some NaNs in which can cause issues downstream. Now fixed. Yay